### PR TITLE
Add KV cache to v4 model for O(1) per-token inference

### DIFF
--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -450,8 +450,23 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
                     )
                 past_length = key.shape[2]
 
-        cos = self.rope_cos[:, past_length:past_length + S, :, :]
-        sin = self.rope_sin[:, past_length:past_length + S, :, :]
+        required_seq_len = past_length + S
+        if required_seq_len <= self.rope_cos.shape[1]:
+            cos = self.rope_cos[:, past_length:required_seq_len, :, :]
+            sin = self.rope_sin[:, past_length:required_seq_len, :, :]
+        else:
+            rope_cos, rope_sin = compute_rope_freqs(
+                required_seq_len,
+                self.rope_cos.shape[-1],
+                theta=getattr(self.config, "rope_theta", 10000.0),
+                device=x.device,
+            )
+            cos = rope_cos[:, past_length:required_seq_len, :, :].to(
+                device=self.rope_cos.device, dtype=self.rope_cos.dtype
+            )
+            sin = rope_sin[:, past_length:required_seq_len, :, :].to(
+                device=self.rope_sin.device, dtype=self.rope_sin.dtype
+            )
 
         loop_rms: list[Tensor] = []
         total_lb_loss = torch.tensor(0.0, device=x.device)

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -291,7 +291,9 @@ class RecursiveBlockV4(nn.Module):
         rope_cos: Tensor,
         rope_sin: Tensor,
         loop_idx: int,
-    ) -> Tensor:
+        past_key_value: tuple[Tensor, Tensor] | None = None,
+        use_cache: bool = False,
+    ) -> tuple[Tensor, tuple[Tensor, Tensor] | None]:
         B, S, D = x.shape
 
         # Per-pass residual adapter (activation-space, not weight-LoRA)
@@ -306,11 +308,26 @@ class RecursiveBlockV4(nn.Module):
         k = k.view(B, S, self.heads, self.head_dim)
         v = v.view(B, S, self.heads, self.head_dim)
 
+        # Apply RoPE to new positions only (cos/sin pre-sliced by caller)
         q = apply_rope(q, rope_cos, rope_sin)
         k = apply_rope(k, rope_cos, rope_sin)
 
+        # Transpose to (B, heads, S, head_dim) for attention
         q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
-        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+        # Concatenate with cached KV from previous generation steps
+        if past_key_value is not None:
+            k = torch.cat([past_key_value[0], k], dim=2)
+            v = torch.cat([past_key_value[1], v], dim=2)
+
+        present_kv = (k, v) if use_cache else None
+
+        # is_causal=True works for both prefill (Q_len==K_len) and
+        # single-token decode (Q_len=1, K_len>1) via PyTorch's upper-left
+        # aligned causal mask.  Disable only when decoding a single token
+        # where no masking is needed (minor optimisation).
+        is_causal = (q.shape[2] == k.shape[2])
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal)
         attn_out = attn_out.transpose(1, 2).contiguous().view(B, S, D)
 
         x = x_mod + self.out_proj(attn_out)
@@ -320,7 +337,7 @@ class RecursiveBlockV4(nn.Module):
         h_moe = self.moe(self.norm_moe(x), loop_idx)
         x = x + self.dense_gate * h_dense + self.moe_gate * h_moe
 
-        return x
+        return x, present_kv
 
 
 # ── Main Model ──────────────────────────────────────────────────────────
@@ -382,47 +399,76 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
 
         self.post_init()
 
-    def forward(self, input_ids: Tensor, **kwargs) -> tuple[Tensor, list[Tensor], Tensor, Tensor]:
+    def forward(
+        self,
+        input_ids: Tensor,
+        past_key_values: list[tuple[Tensor, Tensor]] | None = None,
+        use_cache: bool = False,
+        **kwargs,
+    ) -> tuple[Tensor, list[Tensor], Tensor, Tensor, list[tuple[Tensor, Tensor]] | None]:
         """Forward pass.
 
+        Args:
+            input_ids: Token indices (B, S).
+            past_key_values: KV cache — list of (K, V) tuples, one per
+                effective layer (num_blocks × recursive_loops entries).
+                Each tensor has shape (B, heads, cached_S, head_dim).
+            use_cache: Whether to return updated KV cache for generation.
+
         Returns:
-            (hidden_states, loop_rms_list, total_load_balance_loss, total_z_loss)
+            (hidden_states, loop_rms_list, total_load_balance_loss,
+             total_z_loss, present_key_values)
         """
         x = self.embedding(input_ids)
         S = input_ids.shape[1]
-        cos = self.rope_cos[:, :S, :, :]
-        sin = self.rope_sin[:, :S, :, :]
+
+        # Determine position offset from cached sequence length
+        past_length = 0
+        if past_key_values is not None and past_key_values[0] is not None:
+            past_length = past_key_values[0][0].shape[2]
+
+        cos = self.rope_cos[:, past_length:past_length + S, :, :]
+        sin = self.rope_sin[:, past_length:past_length + S, :, :]
 
         loop_rms: list[Tensor] = []
         total_lb_loss = torch.tensor(0.0, device=x.device)
         total_z_loss = torch.tensor(0.0, device=x.device)
 
         use_ckpt = self.gradient_checkpointing and self.training
+        presents: list[tuple[Tensor, Tensor]] | None = [] if use_cache else None
 
         for loop in range(self.config.recursive_loops):
             for block_idx, block in enumerate(self.blocks):
                 idx = loop * self.config.num_blocks + block_idx
                 adapter_a = self.adapters_a[idx]
                 adapter_b = self.adapters_b[idx]
+
+                layer_past = past_key_values[idx] if past_key_values is not None else None
+
                 if use_ckpt:
-                    # Wrap in closure to capture non-tensor args (adapter_scale,
-                    # loop_idx) — gradient_checkpoint only accepts tensor inputs.
+                    # Gradient checkpointing (training only, never with cache).
+                    # Wrap in closure to capture non-tensor args.
                     def _block_fn(
                         _x, _a, _b, _cos, _sin,
                         _block=block, _scale=self.adapter_scale, _loop=loop,
                     ):
-                        return _block(_x, _a, _b, _scale, _cos, _sin, _loop)
+                        return _block(_x, _a, _b, _scale, _cos, _sin, _loop)[0]
 
                     x = gradient_checkpoint(
                         _block_fn, x, adapter_a, adapter_b, cos, sin,
                         use_reentrant=False,
                     )
                 else:
-                    x = block(
+                    x, present_kv = block(
                         x, adapter_a, adapter_b,
                         self.adapter_scale, cos, sin,
                         loop_idx=loop,
+                        past_key_value=layer_past,
+                        use_cache=use_cache,
                     )
+                    if presents is not None:
+                        presents.append(present_kv)
+
                 # Accumulate MoE losses (kept separate for independent scaling)
                 if block.moe.load_balance_loss is not None:
                     total_lb_loss = total_lb_loss + block.moe.load_balance_loss
@@ -434,7 +480,7 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
                 x = self.norm_loop(x)
 
         x = self.norm_out(x)
-        return x, loop_rms, total_lb_loss, total_z_loss
+        return x, loop_rms, total_lb_loss, total_z_loss, presents
 
 
 class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
@@ -459,9 +505,15 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
         self,
         input_ids: Tensor,
         labels: Tensor | None = None,
+        past_key_values: list[tuple[Tensor, Tensor]] | None = None,
+        use_cache: bool = False,
         **kwargs,
     ) -> CausalLMOutputWithPast:
-        hidden, loop_rms, lb_loss, z_loss = self.model(input_ids)
+        hidden, loop_rms, lb_loss, z_loss, presents = self.model(
+            input_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+        )
 
         # Weight-tied LM head
         logits = F.linear(hidden, self.model.embedding.weight)
@@ -487,6 +539,7 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
         return CausalLMOutputWithPast(
             loss=loss,
             logits=logits,
+            past_key_values=presents,
         )
 
     @torch.no_grad()
@@ -498,17 +551,38 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
         top_p: float = 0.9,
         top_k: int = 50,
         eos_token_id: int | None = None,
+        use_cache: bool = True,
         **kwargs,
     ) -> Tensor:
-        """Generate tokens autoregressively with top-p/top-k sampling."""
+        """Generate tokens autoregressively with KV cache and top-p/top-k sampling.
+
+        On the first step the full prompt is processed and KV states are
+        cached.  Subsequent steps feed only the latest token, reusing the
+        cache for O(1) attention per new token instead of O(n).
+        """
         if eos_token_id is None:
             eos_token_id = self.config.eos_token_id
 
         generated = input_ids.clone()
+        past_key_values = None
 
         for _ in range(max_new_tokens):
-            context = generated[:, -self.config.max_position_embeddings:]
-            outputs = self.forward(context)
+            if past_key_values is not None:
+                # Incremental decode: only the latest token
+                model_input = generated[:, -1:]
+            else:
+                # Prefill: full context (capped to max position embeddings)
+                model_input = generated[:, -self.config.max_position_embeddings:]
+
+            outputs = self.forward(
+                model_input,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+            )
+
+            if use_cache:
+                past_key_values = outputs.past_key_values
+
             next_logits = outputs.logits[:, -1, :self.config.real_vocab_size].float()
 
             if temperature > 0:

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -646,8 +646,14 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
                 # Trim KV cache to a sliding window so memory stays bounded and
                 # RoPE positions never exceed max_position_embeddings.
                 max_len = self.config.max_position_embeddings
-                if past_key_values is not None and past_key_values[0] is not None:
-                    cached_len = past_key_values[0][0].shape[2]
+                first = past_key_values[0] if past_key_values else None
+                if (
+                    first is not None
+                    and isinstance(first, tuple)
+                    and len(first) == 2
+                    and isinstance(first[0], torch.Tensor)
+                ):
+                    cached_len = first[0].shape[2]
                     if cached_len > max_len:
                         past_key_values = [
                             (kv[0][:, :, -max_len:, :], kv[1][:, :, -max_len:, :])

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -490,6 +490,12 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
         total_z_loss = torch.tensor(0.0, device=x.device)
 
         use_ckpt = self.gradient_checkpointing and self.training
+        if use_ckpt and (use_cache or past_key_values is not None):
+            raise ValueError(
+                "KV caching (use_cache=True or past_key_values) is incompatible with "
+                "gradient checkpointing. Disable gradient_checkpointing or set "
+                "use_cache=False."
+            )
         presents: list[tuple[Tensor, Tensor]] | None = [] if use_cache else None
 
         for loop in range(self.config.recursive_loops):
@@ -637,6 +643,17 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
 
             if use_cache:
                 past_key_values = outputs.past_key_values
+                # Trim KV cache to a sliding window so memory stays bounded and
+                # RoPE positions never exceed max_position_embeddings.
+                max_len = self.config.max_position_embeddings
+                if past_key_values is not None and past_key_values[0] is not None:
+                    cached_len = past_key_values[0][0].shape[2]
+                    if cached_len > max_len:
+                        past_key_values = [
+                            (kv[0][:, :, -max_len:, :], kv[1][:, :, -max_len:, :])
+                            if kv is not None else None
+                            for kv in past_key_values
+                        ]
 
             next_logits = outputs.logits[:, -1, :self.config.real_vocab_size].float()
 

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -421,11 +421,34 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
         """
         x = self.embedding(input_ids)
         S = input_ids.shape[1]
+        expected_past_layers = self.config.num_blocks * self.config.recursive_loops
 
-        # Determine position offset from cached sequence length
+        # Validate KV cache shape/length before indexing into it.
         past_length = 0
-        if past_key_values is not None and past_key_values[0] is not None:
-            past_length = past_key_values[0][0].shape[2]
+        if past_key_values is not None:
+            if len(past_key_values) != expected_past_layers:
+                raise ValueError(
+                    "Invalid past_key_values: expected "
+                    f"{expected_past_layers} entries (num_blocks * recursive_loops), "
+                    f"got {len(past_key_values)}."
+                )
+            for idx, layer_past in enumerate(past_key_values):
+                if layer_past is not None and (
+                    not isinstance(layer_past, tuple) or len(layer_past) != 2
+                ):
+                    raise ValueError(
+                        "Invalid past_key_values: each entry must be None or a "
+                        f"(key, value) tuple, but entry {idx} has type "
+                        f"{type(layer_past).__name__}."
+                    )
+            if past_key_values[0] is not None:
+                key, value = past_key_values[0]
+                if not isinstance(key, torch.Tensor) or not isinstance(value, torch.Tensor):
+                    raise ValueError(
+                        "Invalid past_key_values: each non-None entry must contain "
+                        "torch.Tensor key/value tensors."
+                    )
+                past_length = key.shape[2]
 
         cos = self.rope_cos[:, past_length:past_length + S, :, :]
         sin = self.rope_sin[:, past_length:past_length + S, :, :]

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -316,18 +316,35 @@ class RecursiveBlockV4(nn.Module):
         q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
 
         # Concatenate with cached KV from previous generation steps
+        past_len = past_key_value[0].shape[2] if past_key_value is not None else 0
         if past_key_value is not None:
             k = torch.cat([past_key_value[0], k], dim=2)
             v = torch.cat([past_key_value[1], v], dim=2)
 
         present_kv = (k, v) if use_cache else None
 
-        # is_causal=True works for both prefill (Q_len==K_len) and
-        # single-token decode (Q_len=1, K_len>1) via PyTorch's upper-left
-        # aligned causal mask.  Disable only when decoding a single token
-        # where no masking is needed (minor optimisation).
-        is_causal = (q.shape[2] == k.shape[2])
-        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal)
+        # Preserve autoregressive masking for cached multi-token decode.
+        # - Prefill (Q_len == K_len): use the built-in causal path.
+        # - Single-token decode (Q_len == 1): no mask is needed.
+        # - Cached chunked decode (past_len > 0 and Q_len > 1): provide an
+        #   explicit causal mask shifted by the cache length so earlier new
+        #   tokens cannot attend to later new tokens in the same chunk.
+        q_len = q.shape[2]
+        k_len = k.shape[2]
+        if past_len > 0 and q_len > 1:
+            attn_mask = torch.full(
+                (q_len, k_len),
+                float("-inf"),
+                device=q.device,
+                dtype=q.dtype,
+            )
+            attn_mask = torch.triu(attn_mask, diagonal=1 + past_len)
+            attn_out = F.scaled_dot_product_attention(
+                q, k, v, attn_mask=attn_mask, is_causal=False
+            )
+        else:
+            is_causal = (q_len == k_len)
+            attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal)
         attn_out = attn_out.transpose(1, 2).contiguous().view(B, S, D)
 
         x = x_mod + self.out_proj(attn_out)

--- a/tests/test_v4_model.py
+++ b/tests/test_v4_model.py
@@ -1,0 +1,182 @@
+"""Tests for NanoOSRT v4 model with KV cache support."""
+
+import pytest
+import torch
+
+from nano_osrt.v4_config import NanoOSRTv4Config
+from nano_osrt.v4_model import NanoOSRTv4ForCausalLM, NanoOSRTv4Model
+
+
+@pytest.fixture()
+def tiny_v4_config() -> NanoOSRTv4Config:
+    """A tiny v4 config suitable for CPU tests."""
+    return NanoOSRTv4Config(
+        dim=64,
+        heads=4,
+        head_dim=16,
+        vocab_size=256,
+        real_vocab_size=256,
+        num_blocks=2,
+        recursive_loops=2,
+        adapter_rank=4,
+        adapter_alpha=4.0,
+        dense_hidden=128,
+        num_experts=4,
+        num_shared_experts=1,
+        num_routed_experts=3,
+        top_k_experts=2,
+        expert_hidden=64,
+        max_position_embeddings=128,
+    )
+
+
+# ── Basic forward / backward compat ──────────────────────────────────
+
+
+class TestV4ModelBasic:
+    def test_instantiation(self, tiny_v4_config: NanoOSRTv4Config) -> None:
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        assert isinstance(model, NanoOSRTv4ForCausalLM)
+
+    def test_forward_without_cache(self, tiny_v4_config: NanoOSRTv4Config) -> None:
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        model.eval()
+        input_ids = torch.randint(0, tiny_v4_config.vocab_size, (2, 8))
+        outputs = model(input_ids)
+        assert outputs.logits.shape == (2, 8, tiny_v4_config.vocab_size)
+        assert outputs.past_key_values is None
+
+    def test_forward_with_labels(self, tiny_v4_config: NanoOSRTv4Config) -> None:
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        model.eval()
+        input_ids = torch.randint(0, tiny_v4_config.vocab_size, (2, 8))
+        labels = torch.randint(0, tiny_v4_config.real_vocab_size, (2, 8))
+        outputs = model(input_ids, labels=labels)
+        assert outputs.loss is not None
+        assert outputs.loss.ndim == 0
+
+
+# ── KV cache correctness ─────────────────────────────────────────────
+
+
+class TestKVCache:
+    def test_forward_returns_cache_when_requested(
+        self, tiny_v4_config: NanoOSRTv4Config
+    ) -> None:
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        model.eval()
+        input_ids = torch.randint(0, tiny_v4_config.vocab_size, (1, 8))
+        outputs = model(input_ids, use_cache=True)
+
+        # Should have num_blocks * recursive_loops cache entries
+        expected_layers = tiny_v4_config.num_blocks * tiny_v4_config.recursive_loops
+        assert outputs.past_key_values is not None
+        assert len(outputs.past_key_values) == expected_layers
+
+        # Each entry is (K, V) with shape (B, heads, S, head_dim)
+        for k, v in outputs.past_key_values:
+            assert k.shape == (1, tiny_v4_config.heads, 8, tiny_v4_config.head_dim)
+            assert v.shape == (1, tiny_v4_config.heads, 8, tiny_v4_config.head_dim)
+
+    def test_incremental_matches_full(
+        self, tiny_v4_config: NanoOSRTv4Config
+    ) -> None:
+        """Verify that incremental decoding produces identical logits to a
+        full forward pass.  This is the critical correctness test for KV
+        cache: given tokens [A, B, C], the logit for position C should be
+        the same whether we process [A, B, C] in one shot or process
+        [A, B] then [C] with cache."""
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        model.eval()
+
+        torch.manual_seed(42)
+        input_ids = torch.randint(0, tiny_v4_config.vocab_size, (1, 6))
+
+        # Full forward pass — logits at every position
+        full_outputs = model(input_ids, use_cache=False)
+        full_logits = full_outputs.logits  # (1, 6, vocab)
+
+        # Incremental: first 4 tokens as prefill, then token 5, then token 6
+        prefill_ids = input_ids[:, :4]
+        prefill_out = model(prefill_ids, use_cache=True)
+        cache = prefill_out.past_key_values
+
+        step1_ids = input_ids[:, 4:5]
+        step1_out = model(step1_ids, past_key_values=cache, use_cache=True)
+        cache = step1_out.past_key_values
+
+        step2_ids = input_ids[:, 5:6]
+        step2_out = model(step2_ids, past_key_values=cache, use_cache=True)
+
+        # The logit for the last position should match
+        torch.testing.assert_close(
+            full_logits[:, 5, :],
+            step2_out.logits[:, 0, :],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+        # The logit at position 4 should also match
+        torch.testing.assert_close(
+            full_logits[:, 4, :],
+            step1_out.logits[:, 0, :],
+            atol=1e-4,
+            rtol=1e-4,
+        )
+
+    def test_cache_grows_correctly(
+        self, tiny_v4_config: NanoOSRTv4Config
+    ) -> None:
+        """Check that the cached sequence length grows by 1 each step."""
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        model.eval()
+        input_ids = torch.randint(0, tiny_v4_config.vocab_size, (1, 4))
+
+        # Prefill
+        out = model(input_ids, use_cache=True)
+        assert out.past_key_values[0][0].shape[2] == 4
+
+        # Step 1
+        new_token = torch.randint(0, tiny_v4_config.vocab_size, (1, 1))
+        out = model(new_token, past_key_values=out.past_key_values, use_cache=True)
+        assert out.past_key_values[0][0].shape[2] == 5
+
+        # Step 2
+        new_token = torch.randint(0, tiny_v4_config.vocab_size, (1, 1))
+        out = model(new_token, past_key_values=out.past_key_values, use_cache=True)
+        assert out.past_key_values[0][0].shape[2] == 6
+
+
+# ── Generate ─────────────────────────────────────────────────────────
+
+
+class TestGenerate:
+    def test_generate_with_cache(self, tiny_v4_config: NanoOSRTv4Config) -> None:
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        model.eval()
+        input_ids = torch.randint(0, tiny_v4_config.vocab_size, (1, 4))
+        out = model.generate(input_ids, max_new_tokens=5, temperature=1.0, use_cache=True)
+        assert out.shape == (1, 9)  # 4 prompt + 5 generated
+
+    def test_generate_without_cache(self, tiny_v4_config: NanoOSRTv4Config) -> None:
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        model.eval()
+        input_ids = torch.randint(0, tiny_v4_config.vocab_size, (1, 4))
+        out = model.generate(input_ids, max_new_tokens=5, temperature=1.0, use_cache=False)
+        assert out.shape == (1, 9)
+
+    def test_generate_greedy_deterministic(
+        self, tiny_v4_config: NanoOSRTv4Config
+    ) -> None:
+        """Greedy generation (temperature=0) with and without cache should
+        produce identical token sequences."""
+        model = NanoOSRTv4ForCausalLM(tiny_v4_config)
+        model.eval()
+        input_ids = torch.randint(0, tiny_v4_config.vocab_size, (1, 4))
+
+        out_cached = model.generate(
+            input_ids.clone(), max_new_tokens=8, temperature=0.0, use_cache=True,
+        )
+        out_nocache = model.generate(
+            input_ids.clone(), max_new_tokens=8, temperature=0.0, use_cache=False,
+        )
+        assert torch.equal(out_cached, out_nocache)

--- a/tests/test_v4_model.py
+++ b/tests/test_v4_model.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 
 from nano_osrt.v4_config import NanoOSRTv4Config
-from nano_osrt.v4_model import NanoOSRTv4ForCausalLM, NanoOSRTv4Model
+from nano_osrt.v4_model import NanoOSRTv4ForCausalLM
 
 
 @pytest.fixture()


### PR DESCRIPTION
The v4 model previously recomputed attention over the full context at
every generation step, making inference O(n²).  This adds a KV cache
that stores key/value states across all 18 effective layers (3 blocks
× 6 recursive loops), reducing per-token cost to O(1).

Changes:
- RecursiveBlockV4: accept past_key_value, concatenate with new K/V
  after RoPE, return present cache when use_cache=True
- NanoOSRTv4Model: thread past_key_values through all effective layers,
  offset RoPE positions by cached sequence length
- NanoOSRTv4ForCausalLM: pass through cache params, return in
  CausalLMOutputWithPast
- generate(): prefill on first step, then feed only the last token
  with cached KV on subsequent steps
- Add comprehensive tests (9 cases) covering cache shape, incremental-
  vs-full equivalence, cache growth, and greedy determinism

https://claude.ai/code/session_01PGvNNY9zbdRRWy4fXT71Fw