### PR TITLE
v4: capacity-capped MoE routing + vectorised dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@
 
 ### v4: Recursive MoE (In Development)
 
-356M physical parameters with Mixture of Experts. 3 physical blocks x 6 loops = 18 effective layers. Dense FFN + MoE (1 shared + 11 routed experts, top-2) in parallel residual.
+306M physical parameters with Mixture of Experts. 3 physical blocks x 6 loops = 18 effective layers. Dense FFN + MoE (1 shared + 11 routed experts, top-2) in parallel residual.
 
 | Property | Value |
 |----------|-------|
-| Physical params | ~356M |
-| Active params/token | ~180M |
-| Effective params | ~2.1B |
+| Physical params | ~306M |
+| Active params/token (transformer body) | ~130M |
+| Total compute (recursive ×6 block applications) | ~1.8B |
 | Architecture | 3 blocks x 6 loops = 18 effective layers |
 | MoE | 12 experts (1 shared + 11 routed, top-2) |
 | Hidden dim | 1536 |
 | Attention heads | 24 (head_dim=64) |
-| Tokenizer | Custom 64K BPE (trained on code + text + Wikipedia) |
+| Tokenizer | Custom 32K BPE (trained on 10GB of text + code + Wikipedia) |
 | Context length | 8192 (progressive: 2048 -> 4096 -> 8192) |
 | Target training data | 50B tokens |
 | RoPE scaling | NTK-aware for inference beyond training length |
@@ -216,21 +216,29 @@
          +---> output = shared_out + weighted_sum(selected_expert_outputs)
 ```
 
-**Parameter budget (v4):**
+**Parameter budget (v4, 32K vocab):**
 
 ```
-  Token Embedding       101M  [====================]                    28.3%
-  MoE Routed (11)       156M  [================================]        43.7%
-  Dense FFN x3           57M  [============]                            15.9%
-  Attention x3           28M  [======]                                   7.9%
-  Shared Expert x3       14M  [===]                                      3.9%
-  Adapters x18            1M  []                                         0.2%
-  Router + Loop Emb      <1M  []                                         0.0%
+  MoE Routed (11 experts) 156M  [================================]      50.9%
+  Dense FFN x3             57M  [============]                          18.5%
+  Token Embedding          50M  [==========]                            16.4%
+  Attention x3             28M  [======]                                 9.3%
+  Shared Expert x3         14M  [===]                                    4.6%
+  Adapters x18              1M  []                                       0.3%
+  Router + Loop Emb       <1M  []                                        0.0%
   ─────────────────────────────────────────────────────────────────
-  Total Physical       ~356M
-  Active / Token       ~180M   (shared + 2 of 11 routed)
-  Effective            ~2.1B   (recursive x6)
+  Total Physical         ~306M
+  Active transformer body ~130M   per-token compute (excl. embedding lookup)
+  Block applications      6x     via recursive weight sharing
 ```
+
+Note on "effective params": recursion gives 18 block applications, not 18
+independent sets of weights. The model has 306M **physical** parameters;
+each forward runs the body ~6 times with unique per-pass adapters and
+loop-conditioned routing, so the compute budget is comparable to a model
+of roughly ~1.8B FLOPs per token — but with much tighter memorisation
+capacity than a dense 1.8B model. Treat this as iterative refinement on
+a budget, not a 1:1 parameter substitute.
 
 ### Per-Pass Residual Adapters
 
@@ -330,7 +338,7 @@ Each tag is a single token in the v4 tokenizer -- no multi-token string matching
          |  |   Foundation    |                         |            |
          |  |     2048        |                         |            |
     ─────+--+-----------------+-------------------------+------------+---> steps
-         0              15K                        250K          300K
+         0              10K                        250K          300K
 ```
 
 ### Training Pipeline Overview
@@ -338,7 +346,7 @@ Each tag is a single token in the v4 tokenizer -- no multi-token string matching
 ```
   +===========+     +==========+     +========+     +==========+     +======+
   | Tokenizer |---->| Pretrain |---->|  SFT   |---->|  GRPO    |---->| Eval |
-  | (64K BPE) |     | (300K    |     | (5K    |     | (2K      |     |      |
+  | (32K BPE) |     | (300K    |     | (5K    |     | (2K      |     |      |
   |  10GB     |     |  steps)  |     |  steps)|     |  steps)  |     |      |
   +===========+     +==========+     +========+     +==========+     +======+
        |                 |               |               |               |
@@ -371,7 +379,7 @@ Stage 4: Code SFT     -> 7K steps (2 epochs), AdamW + HRA, seq_len 4096
 ### v4 Pipeline (Planned)
 
 ```
-Step 0: Tokenizer     -> Train custom 64K BPE on 10GB text+code+wiki
+Step 0: Tokenizer     -> Train custom 32K BPE on 10GB text+code+wiki
 Step 1: Pretrain      -> 300K steps, progressive seq_len 2048->4096->8192
   Foundation: TinyStories + CodeParrot (15K steps)
   Knowledge:  FineWeb-Edu + CodeParrot + Wikipedia (235K steps)
@@ -430,7 +438,7 @@ uv run modal run app.py --stage eval
 ### v4 Training
 
 ```bash
-# Train custom 64K tokenizer
+# Train custom 32K tokenizer
 uv run modal run --detach app_v4.py --stage tokenizer
 
 # Pre-training (progressive seq_len)
@@ -485,7 +493,7 @@ nano-osrt-100m/
 │   └── v4_sft_train.py             # SFT training loop
 │
 ├── scripts/
-│   └── train_tokenizer.py          # Custom 64K BPE tokenizer training
+│   └── train_tokenizer.py          # Custom 32K BPE tokenizer training
 │
 ├── docs/
 │   ├── training-report.md          # v3 end-to-end training report
@@ -539,7 +547,7 @@ W&B project: [nano-osrt-100m](https://wandb.ai/codhe-synextra/nano-osrt-100m) | 
 
 | Version | Key Changes |
 |---------|-------------|
-| **v4.0** (dev) | 3 blocks, MoE (12 experts, top-2), 64K custom tokenizer, progressive seq_len, native tags, HF-native |
+| **v4.0** (dev) | 3 blocks, MoE (12 experts, top-2), 32K custom tokenizer, parallel adapter residual, dense-first MoE gating, additive loop-aware router, progressive seq_len, native tags, HF-native |
 | **v3.3** | Code SFT (7K steps, 2 epochs), HRA adapters (+11.2M params), HF inference wrapper, IFEval benchmark |
 | **v3.2** | Post-training pipeline: Math SFT + GRPO + improved reward functions |
 | **v3.1** | RoPE, FP32 master weights, dynamic vocab, SmolTalk formatting |

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ uv run modal run app.py --stage eval
 ### v4 Training
 
 ```bash
-# Train custom 32K tokenizer
+# Train custom 32K tokenizer (~8 min on A100, ~$2)
 uv run modal run --detach app_v4.py --stage tokenizer
 
 # Pre-training (progressive seq_len)
@@ -453,6 +453,25 @@ uv run modal run --detach app_v4.py --stage grpo
 # Benchmarks
 uv run modal run app_v4.py --stage eval
 ```
+
+**Recommended first run: sanity check, not full send.** Launch the pretrain
+stage, watch the first ~500-1000 steps in W&B, and confirm the following
+signals before committing more GPU hours:
+
+| What to watch | Healthy signal |
+|---|---|
+| `train/loss` | Drops from ~10.4 baseline (ln 32768) toward ~7-8 within the warmup |
+| `train/tok_per_sec` | Stable at >20K on H100 at seq_len 2048 |
+| `moe/dense_gate_b{0,1,2}` | Starts at 1.0, drifts slowly — not collapsing |
+| `moe/moe_gate_b{0,1,2}` | Starts at 0.01, grows as router learns |
+| `moe/entropy_mean` | ≥ 2.0 (router not collapsing; ln(11) ≈ 2.40 is max) |
+| `moe/expert_max_mean` | < 0.4 (no single expert eating most tokens) |
+| `moe/load_balance_loss_mean` | Stable, not exploding |
+| `eval/loss` | Slowly improving on the held-out FineWeb-Edu stream |
+
+If anything is off — routing collapse, slow tok/s, NaN loss — stop the run
+early, diagnose, and restart. Cheap to iterate, expensive to burn the
+whole budget on a broken run.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,28 +26,33 @@
 
 ### v4: Recursive MoE (In Development)
 
-306M physical parameters with Mixture of Experts. 3 physical blocks x 6 loops = 18 effective layers. Dense FFN + MoE (1 shared + 11 routed experts, top-2) in parallel residual.
+306M physical parameters with Mixture of Experts. 3 physical blocks x 6 loops = 18 effective layers. Dense FFN + MoE (1 shared + 11 routed experts, top-2) in parallel residual with capacity-capped routing.
 
 | Property | Value |
 |----------|-------|
 | Physical params | ~306M |
 | Active params/token (transformer body) | ~130M |
-| Total compute (recursive ×6 block applications) | ~1.8B |
+| Total compute (recursive x6 block applications) | ~1.8B |
 | Architecture | 3 blocks x 6 loops = 18 effective layers |
-| MoE | 12 experts (1 shared + 11 routed, top-2) |
+| MoE | 12 experts (1 shared + 11 routed, top-2 capacity-capped) |
 | Hidden dim | 1536 |
 | Attention heads | 24 (head_dim=64) |
-| Tokenizer | Custom 32K BPE (trained on 10GB of text + code + Wikipedia) |
+| Tokenizer | Custom 32K BPE (trained on 2GB of text + code + Wikipedia) |
 | Context length | 8192 (progressive: 2048 -> 4096 -> 8192) |
 | Target training data | 50B tokens |
 | RoPE scaling | NTK-aware for inference beyond training length |
+| KV cache | O(1) per-token inference with incremental decoding |
 
 **Key v4 features:**
-- Loop-aware router with learned loop embeddings (sigmoid gating, DeepSeek-V3 style)
-- Learnable dense/MoE gates for parallel residual scaling
-- Router z-loss (ST-MoE/PaLM) for training stability
-- Batched scatter-gather expert dispatch
-- Gradient checkpointing for long sequences
+- **Capacity-capped routing:** each expert has a hard per-batch token cap (capacity_factor=1.25), structurally preventing any expert from dominating. Tokens scan candidates in descending sigmoid score and are assigned to the first top-k experts with remaining capacity. Same path in training and inference.
+- Loop-aware router with learned loop embeddings (additive, not concat -- halves router params)
+- Row-normalized router init (equal expert norms at step 0)
+- Learnable dense/MoE gates for parallel residual scaling (dense_gate=1.0, moe_gate=0.01 init)
+- Soft warmup (steps 0-500) -> blend (500-1000) -> hard capacity-capped dispatch (1000+)
+- Vectorised capacity assignment (sort + segment-cumsum, race-free)
+- KV cache for O(1) per-token autoregressive generation
+- Gradient checkpointing (auto-enabled during soft/blend phases and for seq_len >= 4096)
+- Resilient HF streaming data loader (auto-reconnect on shard failures)
 - Native single-token tags: `<|think|>`, `<|/think|>`, `<|answer|>`, `<|/answer|>`, `<|user|>`, `<|assistant|>`, `<|system|>`, FIM tokens
 - HuggingFace `PreTrainedModel` compatible from day one
 
@@ -129,7 +134,7 @@
           Input Token IDs (B, S)
                    |
           +--------v--------+
-          |  Token Embedding |  (65536 x 1536)
+          |  Token Embedding |  (32768 x 1536, weight-tied with LM head)
           +---------+-------+
                     |
                     |     +-------------------------------------------+
@@ -145,11 +150,11 @@
    ||  +------------------------------------------------------------+  ||
    ||  |  RecursiveBlockV4                                          |  ||
    ||  |                                                            |  ||
-   ||  |  x_mod = x + scale * (x @ adapter_a[i] @ adapter_b[i])    |  ||
+   ||  |  adapter_out = scale * (x @ adapter_a[i] @ adapter_b[i])  |  ||
    ||  |                                                            |  ||
    ||  |  +== ATTENTION ========================================+   |  ||
    ||  |  | RMSNorm -> QKV (1536->4608) -> RoPE -> Causal SDPA |   |  ||
-   ||  |  | -> Out Proj (1536->1536) + Residual                 |   |  ||
+   ||  |  | -> Out Proj + adapter_out + Residual (parallel)     |   |  ||
    ||  |  +=====================================================+   |  ||
    ||  |                          |                                 |  ||
    ||  |           +--------------+---------------+                 |  ||
@@ -159,11 +164,13 @@
    ||  |  |                   |  |                               |  |  ||
    ||  |  | RMSNorm           |  | RMSNorm                      |  |  ||
    ||  |  | SwiGLU            |  |     +---------------------+  |  |  ||
-   ||  |  | (1536->4096->1536)|  |     |  Loop-Aware Router   |  |  |  ||
-   ||  |  |                   |  |     |  h + loop_emb -> sig  |  |  |  ||
+   ||  |  | (1536->4096->1536)|  |     | Loop-Aware Router    |  |  |  ||
+   ||  |  |                   |  |     | h + loop_emb -> sig  |  |  |  ||
    ||  |  |                   |  |     +----------+----------+  |  |  ||
    ||  |  |                   |  |                |             |  |  ||
-   ||  |  |                   |  |         top-2 selection      |  |  ||
+   ||  |  |                   |  |    capacity-capped top-2     |  |  ||
+   ||  |  |                   |  |    (scan candidates, cap     |  |  ||
+   ||  |  |                   |  |     per-expert token limit)  |  |  ||
    ||  |  |                   |  |        /       |       \     |  |  ||
    ||  |  |                   |  |  +--------+ +-----+ +-----+ |  |  ||
    ||  |  |                   |  |  | Shared | | E_i | | E_j | |  |  ||
@@ -198,23 +205,36 @@
                               Logits (B, S, vocab)
 ```
 
-**MoE routing detail:**
+**MoE routing detail (capacity-capped):**
 
 ```
   Hidden state (B, S, 1536)
          |
-         +---> concat with loop_embedding[loop_idx]  --> (B, S, 3072)
+         +---> add loop_embedding[loop_idx]  --> (B, S, 1536)  [additive, not concat]
          |
-         +---> Router linear (3072 -> 11)  --> sigmoid --> top-2 selection
+         +---> Router linear (1536 -> 11)  --> sigmoid scores
+         |     (row-normalised init: all expert rows same norm)
+         |
+         +---> Capacity-capped candidate scan:
+         |     1. Sort tokens' top-11 candidates by sigmoid score
+         |     2. For each candidate rank, assign tokens to experts
+         |        that still have capacity (vectorised sort + cumcount)
+         |     3. Per-expert cap = ceil(1.25 * N * 2 / 11)
+         |     4. Each token gets exactly 2 experts (overflow ~0%)
+         |     5. Weights from clean sigmoid, renormalised
          |
          |     Expert 0: SwiGLU(1536 -> 1024 -> 1536)  [always active = shared]
-         |     Expert 1: SwiGLU(1536 -> 1024 -> 1536)  \
-         |     Expert 2: SwiGLU(1536 -> 1024 -> 1536)   |
-         |     ...                                       +-- top-2 selected
-         |     Expert 11: SwiGLU(1536 -> 1024 -> 1536)  /
+         |     Expert 1-11: SwiGLU(1536 -> 1024 -> 1536)  [2 selected per token]
          |
-         +---> output = shared_out + weighted_sum(selected_expert_outputs)
+         +---> output = shared_out + weighted_sum(capped_expert_outputs)
 ```
+
+The capacity cap is a structural guarantee -- no expert can receive more than
+~11.4% of assignments regardless of the router's preferences. This solves the
+deterministic top-k winner lock-in problem that caused routing collapse in all
+soft-regularisation approaches (z-loss, Gumbel noise, proportional bias).
+The router is free to learn token-dependent preferences; the cap just prevents
+those preferences from producing imbalanced load.
 
 **Parameter budget (v4, 32K vocab):**
 
@@ -239,6 +259,135 @@ loop-conditioned routing, so the compute budget is comparable to a model
 of roughly ~1.8B FLOPs per token — but with much tighter memorisation
 capacity than a dense 1.8B model. Treat this as iterative refinement on
 a budget, not a 1:1 parameter substitute.
+
+### Mathematical Formulation
+
+#### Notation
+
+Let $B$ denote batch size, $S$ sequence length, $d$ hidden dimension (1536), $H$ number of attention heads (24), $d_h$ head dimension (64), $N_b$ number of physical blocks (3), $L$ number of recursive loops (6), $E$ total experts (12), $E_s$ shared experts (1), $E_r$ routed experts (11), and $k$ experts selected per token (2).
+
+#### 1. Recursive Forward Pass
+
+The model applies $N_b$ physical blocks $L$ times each, yielding $N_b \times L = 18$ effective layers from 3 sets of weights. For loop $\ell \in \{0, \ldots, L-1\}$ and block $b \in \{0, \ldots, N_b-1\}$:
+
+$$\mathbf{x}^{(\ell, b)} = \text{Block}_b\!\left(\mathbf{x}^{(\ell, b-1)},\; \mathbf{A}_{\ell N_b + b},\; \mathbf{B}_{\ell N_b + b},\; \ell\right)$$
+
+where $\mathbf{x}^{(\ell, 0)} = \text{RMSNorm}(\mathbf{x}^{(\ell-1, N_b-1)})$ for $\ell > 0$ (inter-loop normalisation), and $\mathbf{x}^{(0,0)} = \text{Embed}(\text{input\_ids})$. Each block reuses the same parameters $\text{Block}_b$ across all $L$ loops; only the adapter pairs $(\mathbf{A}_i, \mathbf{B}_i)$ and the loop embedding index $\ell$ vary.
+
+#### 2. Per-Pass Residual Adapters
+
+Each of the $N_b \times L = 18$ effective layers has a unique adapter pair $(\mathbf{A}_i, \mathbf{B}_i)$ with $\mathbf{A}_i \in \mathbb{R}^{d \times r}$, $\mathbf{B}_i \in \mathbb{R}^{r \times d}$ (rank $r = 16$). Unlike weight-space LoRA (Hu et al., 2021), these operate in activation space as a parallel residual branch:
+
+$$\mathbf{x}_{\text{adapted}} = \mathbf{x} + \frac{\alpha}{r}\left(\mathbf{x}\,\mathbf{A}_i\,\mathbf{B}_i\right)$$
+
+where $\alpha = 16$, $r = 16$, giving scale $= 1.0$. At initialisation $\mathbf{B}_i = \mathbf{0}$, so the adapter is a no-op and all loops begin identically. Differentiation emerges through gradient flow during training.
+
+#### 3. Attention with RoPE
+
+Within each block, causal multi-head attention with Rotary Position Embeddings (Su et al., 2021):
+
+$$\mathbf{q}, \mathbf{k}, \mathbf{v} = \text{split}\!\left(\mathbf{W}_{qkv}\,\text{RMSNorm}(\mathbf{x})\right)$$
+
+$$\mathbf{q}' = \text{RoPE}(\mathbf{q}, \cos, \sin), \quad \mathbf{k}' = \text{RoPE}(\mathbf{k}, \cos, \sin)$$
+
+$$\text{Attn}(\mathbf{q}', \mathbf{k}', \mathbf{v}) = \text{softmax}\!\left(\frac{\mathbf{q}'\mathbf{k}'^{\!\top}}{\sqrt{d_h}} + \mathbf{M}_{\text{causal}}\right)\mathbf{v}$$
+
+$$\mathbf{x} \leftarrow \mathbf{x} + \mathbf{W}_o\,\text{Attn}(\mathbf{q}', \mathbf{k}', \mathbf{v}) + \mathbf{x}_{\text{adapted}}$$
+
+where the adapter output is added as a parallel branch alongside the attention output. Optional NTK-aware RoPE scaling (Bloc97, 2023) extends context beyond training length by rescaling $\theta_{\text{eff}} = \theta \cdot f^{d/(d-2)}$ for extension factor $f$.
+
+#### 4. Parallel Dense + MoE FFN
+
+The FFN stage runs a dense SwiGLU network and a Mixture of Experts network in parallel, with learnable scalar gates:
+
+$$\mathbf{h}_{\text{dense}} = \text{SwiGLU}_{\text{dense}}(\text{RMSNorm}(\mathbf{x}))$$
+
+$$\mathbf{h}_{\text{moe}} = \text{MoE}(\text{RMSNorm}(\mathbf{x}), \ell)$$
+
+$$\mathbf{x} \leftarrow \mathbf{x} + g_d \cdot \mathbf{h}_{\text{dense}} + g_m \cdot \mathbf{h}_{\text{moe}}$$
+
+where $g_d, g_m$ are learnable scalars initialised to $g_d = 1.0$, $g_m = 0.01$. This "dense-first" initialisation means the model starts as a nearly pure dense network and gradually incorporates MoE output as the router learns meaningful routing.
+
+Each SwiGLU network computes $\text{SwiGLU}(\mathbf{x}) = \mathbf{W}_{\text{down}}(\text{SiLU}(\mathbf{W}_{\text{gate}}\mathbf{x}) \odot \mathbf{W}_{\text{up}}\mathbf{x})$.
+
+#### 5. Loop-Aware Routing
+
+The router produces per-expert scores conditioned on both the hidden state and the current recursive loop index. A learned embedding $\mathbf{e}_\ell \in \mathbb{R}^d$ is added (not concatenated) to the hidden state before projection:
+
+$$\mathbf{s}_{b,t} = \sigma\!\left(\mathbf{W}_R\,(\mathbf{h}_t + \mathbf{e}_\ell)\right) \in \mathbb{R}^{E_r}$$
+
+where $\sigma$ is the element-wise sigmoid function, $\mathbf{W}_R \in \mathbb{R}^{E_r \times d}$ is the router weight matrix, and $\mathbf{h}_t$ is the normalised hidden state for token $t$. Addition (not concatenation) keeps router parameters at $E_r \times d$ rather than $E_r \times 2d$, since $\mathbf{W}_R[\mathbf{h}; \mathbf{e}] = \mathbf{W}_R^{(1)}\mathbf{h} + \mathbf{W}_R^{(2)}\mathbf{e}$ is equivalent under a linear projection.
+
+**Router initialisation.** $\mathbf{W}_R$ is initialised from $\mathcal{N}(0, 0.02)$ then row-normalised so every expert row has equal norm. This prevents any expert from starting with a larger projection magnitude and winning deterministic top-$k$ tie-breaking at step 0. Loop embeddings are initialised from $\mathcal{N}(0, 0.1)$ (5x the default $0.02$) so that routing is loop-dependent from the first step.
+
+#### 6. Capacity-Capped Expert Selection
+
+Standard deterministic top-$k$ selection suffers from self-reinforcing winner lock-in: small initial logit differences cause the same experts to be selected repeatedly, strengthening their weights through gradient, which increases their logit advantage, creating a positive feedback loop that collapses routing to $k$ out of $E_r$ experts within 30-50 training steps. We verified this failure empirically across six approaches: raw top-$k$, additive Gaussian noise, soft all-expert warmup, Gumbel-top-$k$, proportional bias controller, and importance-weighted regularisation. All failed to prevent collapse.
+
+We adopt **capacity-capped candidate routing**, which provides a structural guarantee on load balance. Define the per-expert capacity:
+
+$$C = \left\lceil \gamma \cdot \frac{N \cdot k}{E_r} \right\rceil$$
+
+where $N = B \times S$ is the total number of tokens in the batch, $k = 2$ is the number of experts per token, and $\gamma = 1.25$ is the capacity factor providing 25% slack above the uniform allocation $N \cdot k / E_r$.
+
+**Algorithm.** For each token, we scan its $E_r$ candidate experts in descending order of sigmoid score $\mathbf{s}_{b,t}$ and assign the first $k$ experts that have remaining capacity. Let $\pi_t$ be the permutation sorting token $t$'s scores in descending order, and let $n_j$ be the running count of tokens assigned to expert $j$. Token $t$ is assigned expert $\pi_t(r)$ at candidate rank $r$ if and only if:
+
+$$n_{\pi_t(r)} < C \quad \text{and} \quad |\{j : t \to j\}| < k$$
+
+After assignment, the dispatch weights for token $t$'s selected experts $\{j_1, j_2\}$ are:
+
+$$w_{t,j} = \frac{\sigma((\mathbf{W}_R(\mathbf{h}_t + \mathbf{e}_\ell))_j)}{\sum_{j' \in \{j_1, j_2\}} \sigma((\mathbf{W}_R(\mathbf{h}_t + \mathbf{e}_\ell))_{j'})}$$
+
+Note that the weights come from the clean sigmoid scores, not from the capacity-assignment order. This preserves meaningful gradient flow to the router: the selected experts receive gradient proportional to their sigmoid score, incentivising the router to produce high scores for experts that reduce loss.
+
+**Vectorised implementation.** To avoid a sequential loop over tokens, we process all tokens in parallel per candidate rank using a sort-and-segment-cumsum approach:
+
+1. For candidate rank $r$: gather each eligible token's desired expert ID.
+2. Sort tokens by expert ID (stable sort preserves token order within groups).
+3. Compute within-group position via segment cumsum: detect group boundaries where sorted expert IDs change, compute cumulative count within each group.
+4. Token at within-group position $p$ fits if $p < C - n_j$ (remaining capacity for expert $j$).
+5. Unsort the fit mask back to original token order and apply assignments.
+6. Update per-expert counts via `scatter_add_`.
+
+This runs in $O(E_r \cdot M \log M)$ where $M$ is the number of eligible tokens (shrinking each iteration as tokens fill their $k$ slots), eliminating the $O(E_r^2)$ inner loop of the naive implementation.
+
+**Structural guarantees.** With $\gamma = 1.25$ and candidate pool size $= E_r$ (all experts), the capacity cap ensures:
+
+$$\max_j \frac{n_j}{N \cdot k} \leq \frac{C}{N \cdot k} = \frac{\gamma}{E_r} \approx 0.114$$
+
+This bound holds by construction regardless of the router's learned preferences. The overflow rate (fraction of tokens receiving fewer than $k$ experts) is empirically $0.000$ with $\gamma = 1.25$ and full candidate pool.
+
+#### 7. MoE Output
+
+The MoE layer output combines the shared expert (always active) with the capacity-capped routed output:
+
+$$\text{MoE}(\mathbf{h}, \ell) = \text{FFN}_{\text{shared}}(\mathbf{h}) + \sum_{j \in \text{capped}(t)} w_{t,j} \cdot \text{FFN}_j(\mathbf{h}_t)$$
+
+where $\text{capped}(t)$ denotes the set of (at most $k$) experts assigned to token $t$ by the capacity-capped algorithm.
+
+#### 8. Training Loss
+
+The training objective combines cross-entropy with a differentiable importance balance regulariser:
+
+$$\mathcal{L} = \mathcal{L}_{\text{CE}} + \lambda_{\text{imp}} \cdot \frac{1}{N_b \cdot L} \sum_{\ell, b} \mathcal{L}_{\text{imp}}^{(\ell, b)}$$
+
+where the importance loss for a single MoE application is:
+
+$$\mathcal{L}_{\text{imp}} = E_r \cdot \sum_{j=1}^{E_r} \left(\bar{p}_j\right)^2, \quad \bar{p}_j = \frac{1}{N} \sum_{t=1}^{N} \text{softmax}\!\left(\frac{\mathbf{W}_R(\mathbf{h}_t + \mathbf{e}_\ell)}{\tau}\right)_j$$
+
+This is minimised at $\mathcal{L}_{\text{imp}} = 1.0$ when the softmax marginal is uniform ($\bar{p}_j = 1/E_r$ for all $j$), and grows quadratically with concentration. The default coefficient is $\lambda_{\text{imp}} = 0.05$ with temperature $\tau = 1.0$. Unlike the capacity cap (which constrains hard assignments), the importance loss provides differentiable gradient pressure on the soft probability distribution, encouraging the router to maintain balanced preferences even though the cap prevents imbalanced outcomes.
+
+#### 9. Routing Schedule
+
+Training proceeds through three routing phases:
+
+| Phase | Steps | Routing | Grad Checkpointing |
+|---|---|---|---|
+| Soft warmup | $[0, 500)$ | All $E_r$ experts run on every token, weighted by $\text{softmax}(\mathbf{s}/\tau)$ | On |
+| Blend | $[500, 1000)$ | $\alpha \cdot \text{capped\_hard} + (1-\alpha) \cdot \text{soft}$, $\alpha$ linear $0 \to 1$ | On |
+| Hard | $[1000, \infty)$ | Capacity-capped top-$k$ only | Off (seq < 4096) |
+
+The soft warmup ensures every expert receives gradient from step 0, preventing dead experts before the router has learned any token-dependent preferences. The blend phase provides a smooth transition so the model's loss trajectory is not disrupted by the switch from dense to sparse expert selection. In the hard phase, only the $k$ capacity-capped experts run per token, reducing compute to $\sim$$130$M active parameters per token.
 
 ### Per-Pass Residual Adapters
 
@@ -455,23 +604,26 @@ uv run modal run app_v4.py --stage eval
 ```
 
 **Recommended first run: sanity check, not full send.** Launch the pretrain
-stage, watch the first ~500-1000 steps in W&B, and confirm the following
+stage, watch the first ~100-500 steps in W&B, and confirm the following
 signals before committing more GPU hours:
 
 | What to watch | Healthy signal |
 |---|---|
-| `train/loss` | Drops from ~10.4 baseline (ln 32768) toward ~7-8 within the warmup |
-| `train/tok_per_sec` | Stable at >20K on H100 at seq_len 2048 |
-| `moe/dense_gate_b{0,1,2}` | Starts at 1.0, drifts slowly — not collapsing |
-| `moe/moe_gate_b{0,1,2}` | Starts at 0.01, grows as router learns |
-| `moe/entropy_mean` | ≥ 2.0 (router not collapsing; ln(11) ≈ 2.40 is max) |
-| `moe/expert_max_mean` | < 0.4 (no single expert eating most tokens) |
-| `moe/load_balance_loss_mean` | Stable, not exploding |
+| `train/loss` | Drops from ~10.7 (ln 32768) toward ~7 by step 100 |
+| `train/tok_per_sec` | 12-15K in soft phase, 18-20K in hard phase (H100) |
+| `moe/clean_expert_max_mean` | Pinned at ~0.114 (= capacity cap bound) |
+| `moe/overflow_rate_mean` | 0.000 (every token gets 2 experts) |
+| `moe/assigned_per_token_mean` | 2.00 |
+| `moe/candidate_rank_mean` | < 4.0 (tokens finding capacity without going deep) |
+| `moe/moe_gate_b{0,1,2}` | Starts at 0.01, climbs steadily (MoE becoming useful) |
+| `moe/dense_gate_b{0,1,2}` | Starts at 1.0, gradually decreases (shifting to MoE) |
+| `moe/raw_assign_entropy_mean` | Diagnostic only -- may collapse, that's OK |
 | `eval/loss` | Slowly improving on the held-out FineWeb-Edu stream |
 
-If anything is off — routing collapse, slow tok/s, NaN loss — stop the run
-early, diagnose, and restart. Cheap to iterate, expensive to burn the
-whole budget on a broken run.
+The capacity cap makes routing collapse structurally impossible -- `expert_max`
+cannot exceed `ceil(capacity_factor * N * top_k / num_routed) / (N * top_k)`.
+If you see `overflow_rate > 0.01` or `assigned_per_token < 1.9`, increase
+`router_candidate_k` (default 11 = num_routed) or `router_capacity_factor`.
 
 ---
 
@@ -544,7 +696,9 @@ Additional benchmarks (GSM8K, HellaSwag) pending.
 | HRA (not LoRA) for post-training | Adds substantial capacity (11-20M params) rather than parameter-efficient fine-tuning |
 | Lion optimizer (pre-training) | Halves optimizer VRAM; competitive perplexity at this scale |
 | MoE alongside dense FFN (v4) | Dense path maintains baseline quality; MoE adds specialist capacity |
-| Loop-aware routing (v4) | Router learns to dispatch differently at each recursive pass |
+| Capacity-capped routing (v4) | Structural load balance guarantee; deterministic top-k collapses without it (confirmed across 6+ sanity runs with soft warmup, Gumbel noise, and proportional bias -- all failed) |
+| Loop-aware routing (v4) | Additive loop embeddings; router learns to dispatch differently at each recursive pass |
+| Soft warmup schedule (v4) | Steps 0-500 use all-expert soft dispatch so every expert gets gradient before hard selection starts |
 | Custom tokenizer (v4) | Optimized for code+text distribution; native single-token tags |
 | Progressive seq_len (v4) | Start short (fast), extend long (capability); RoPE naturally supports this |
 
@@ -555,6 +709,7 @@ Additional benchmarks (GSM8K, HellaSwag) pending.
 Training logs to Weights & Biases with per-stage metrics:
 
 - **Pre-training:** loss, lr, vram, tok/s, phase, loop RMS, adapter similarity
+- **MoE routing (v4):** capped/raw assignment entropy, expert max/min fractions, overflow rate, assigned experts per token, candidate rank mean, gate values, importance loss -- all per-block per-loop
 - **SFT:** loss, lr, vram, token utilization
 - **GRPO:** loss, mean reward, accuracy, KL divergence
 
@@ -566,7 +721,7 @@ W&B project: [nano-osrt-100m](https://wandb.ai/codhe-synextra/nano-osrt-100m) | 
 
 | Version | Key Changes |
 |---------|-------------|
-| **v4.0** (dev) | 3 blocks, MoE (12 experts, top-2), 32K custom tokenizer, parallel adapter residual, dense-first MoE gating, additive loop-aware router, progressive seq_len, native tags, HF-native |
+| **v4.0** (dev) | 3 blocks, MoE (12 experts, capacity-capped top-2), 32K custom tokenizer, parallel adapter residual, dense-first MoE gating, additive loop-aware router with row-norm init, soft warmup + blend + hard routing schedule, vectorised capacity-capped dispatch, KV cache, resilient HF data streaming, progressive seq_len, native tags, HF-native |
 | **v3.3** | Code SFT (7K steps, 2 epochs), HRA adapters (+11.2M params), HF inference wrapper, IFEval benchmark |
 | **v3.2** | Post-training pipeline: Math SFT + GRPO + improved reward functions |
 | **v3.1** | RoPE, FP32 master weights, dynamic vocab, SmolTalk formatting |

--- a/app_v4.py
+++ b/app_v4.py
@@ -51,7 +51,7 @@ tokenizer_vol = modal.Volume.from_name("osrt-v4-tokenizer", create_if_missing=Tr
 
 
 @app.function(
-    gpu="A100",
+    gpu="H100",
     image=image,
     volumes={
         "/vol/checkpoints": vol,
@@ -527,7 +527,7 @@ def grpo():
 
 
 @app.function(
-    gpu="A100",
+    gpu="H100",
     image=image,
     volumes={
         "/vol/checkpoints": vol,

--- a/app_v4.py
+++ b/app_v4.py
@@ -1,12 +1,12 @@
 """NanoOSRT v4 — Modal deployment entrypoint.
 
-~356M physical params (64K vocab + 1536 dim), ~180M active/token,
-~2.1B effective via recursive weight sharing.
+~306M physical params (32K vocab + 1536 dim), ~130M active/token,
+~1.8B effective via recursive weight sharing.
 3 physical blocks × 6 loops = 18 effective layers.
 Dense FFN + MoE (1 shared + 11 routed experts, top-2) in parallel residual.
 
 Stages:
-    modal run app_v4.py --stage tokenizer    Train custom 64K BPE tokenizer
+    modal run app_v4.py --stage tokenizer    Train custom 32K BPE tokenizer
     modal run app_v4.py --stage pretrain     Pre-training (progressive seq_len)
     modal run app_v4.py --stage sft          Balanced SFT (math + code + STEM + general)
     modal run app_v4.py --stage grpo         GRPO reinforcement learning
@@ -58,14 +58,14 @@ tokenizer_vol = modal.Volume.from_name("osrt-v4-tokenizer", create_if_missing=Tr
     timeout=14400,  # 4 hours
 )
 def train_tokenizer():
-    """Train custom 64K BPE tokenizer on pre-training data mix."""
+    """Train custom 32K BPE tokenizer on pre-training data mix."""
     import sys
     sys.path.insert(0, "/root")
 
     from scripts.train_tokenizer import sample_training_data, train_with_hf_tokenizers
 
     print("=" * 60)
-    print("NanoOSRT v4 — Custom 64K Tokenizer Training")
+    print("NanoOSRT v4 — Custom 32K Tokenizer Training")
     print("=" * 60)
 
     # Sample 10GB of training data (proportional to pre-training mix)
@@ -74,7 +74,7 @@ def train_tokenizer():
 
     # Train tokenizer
     output_dir = "/vol/tokenizer"
-    train_with_hf_tokenizers(data_path, vocab_size=65536, output_dir=output_dir)
+    train_with_hf_tokenizers(data_path, vocab_size=32768, output_dir=output_dir)
 
     # Cleanup temp file
     import os
@@ -122,7 +122,7 @@ def pretrain():
     print(f"Tokenizer loaded: vocab_size={len(tok)}")
 
     # Sanity check — if tokenizer is wrong size, warn loudly
-    expected_vocab = 65536
+    expected_vocab = 32768
     if len(tok) != expected_vocab:
         print(f"WARNING: Expected {expected_vocab} vocab but got {len(tok)}!")
         print("  Retrain tokenizer: modal run app_v4.py --stage tokenizer")

--- a/app_v4.py
+++ b/app_v4.py
@@ -24,7 +24,10 @@ app = modal.App("nano-osrt-v4")
 image = (
     modal.Image.debian_slim(python_version="3.11")
     .apt_install("git", "build-essential")
-    .env({"TORCH_LOGS": "perf_hints"})
+    # PYTHONUNBUFFERED=1 forces line-buffered stdout/stderr inside the
+    # container, otherwise long-running stages like tokenizer sampling
+    # look frozen from the local log stream until the buffer flushes.
+    .env({"TORCH_LOGS": "perf_hints", "PYTHONUNBUFFERED": "1"})
     .pip_install(
         "torch==2.10.0+cu128",
         extra_options="--index-url https://download.pytorch.org/whl/cu128",
@@ -62,15 +65,23 @@ def train_tokenizer():
     import sys
     sys.path.insert(0, "/root")
 
+    # Force unbuffered stdout so Modal's log tail shows progress in real
+    # time (belt-and-braces over PYTHONUNBUFFERED in the image env).
+    sys.stdout.reconfigure(line_buffering=True)
+    sys.stderr.reconfigure(line_buffering=True)
+
     from scripts.train_tokenizer import sample_training_data, train_with_hf_tokenizers
 
-    print("=" * 60)
-    print("NanoOSRT v4 — Custom 32K Tokenizer Training")
-    print("=" * 60)
+    print("=" * 60, flush=True)
+    print("NanoOSRT v4 — Custom 32K Tokenizer Training", flush=True)
+    print("=" * 60, flush=True)
 
-    # Sample 10GB of training data (proportional to pre-training mix)
-    print("\nSampling training data...")
-    data_path = sample_training_data(sample_size=10_000_000_000)
+    # Sample 2GB of training data (proportional to pre-training mix).
+    # 2GB is the sweet spot for a 32K BPE tokenizer: diminishing returns
+    # kick in past that, and larger samples expose us to more HF Hub
+    # connection drops (see ~10GB run that died on repeated timeouts).
+    print("\nSampling training data...", flush=True)
+    data_path = sample_training_data(sample_size=2_000_000_000)
 
     # Train tokenizer
     output_dir = "/vol/tokenizer"
@@ -80,7 +91,7 @@ def train_tokenizer():
     import os
     os.remove(data_path)
 
-    print("\nTokenizer saved to Modal volume 'osrt-v4-tokenizer'")
+    print("\nTokenizer saved to Modal volume 'osrt-v4-tokenizer'", flush=True)
 
 
 # =============================================================================

--- a/app_v4.py
+++ b/app_v4.py
@@ -253,14 +253,24 @@ def grpo():
         print(f"Injecting HRA (rank={cfg.hra_rank})...")
         hra_params = inject_hra(model, rank=cfg.hra_rank)
 
-    # Load SFT weights
+    # Load SFT weights — GRPO MUST start from a real SFT checkpoint.
     ckpt_path = cfg.pretrained_checkpoint
-    if os.path.exists(ckpt_path):
-        print(f"Loading SFT weights from {ckpt_path}...")
-        ckpt = torch.load(ckpt_path, map_location=device, weights_only=True)
-        state_dict = ckpt.get("model_state_dict", ckpt)
-        model.load_state_dict(state_dict, strict=False)
-        print("  Loaded.")
+    if not os.path.exists(ckpt_path):
+        raise FileNotFoundError(
+            f"GRPO refuses to start: SFT checkpoint not found at {ckpt_path}. "
+            "Run SFT first (modal run app_v4.py --stage sft)."
+        )
+
+    print(f"Loading SFT weights from {ckpt_path}...")
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=True)
+    state_dict = ckpt.get("model_state_dict", ckpt)
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if missing:
+        print(f"  MISSING keys ({len(missing)}): sample {missing[:3]}")
+    if unexpected:
+        print(f"  UNEXPECTED keys ({len(unexpected)}): sample {unexpected[:3]}")
+    if not missing and not unexpected:
+        print("  Clean load: all keys matched.")
 
     total_params = sum(p.numel() for p in model.parameters())
     print(f"Parameters: {total_params:,}")
@@ -611,8 +621,60 @@ def evaluate(tasks: str = "ifeval", limit: int = 0):
         @property
         def device(self): return self._device
 
-        def tok_encode(self, s, **kw): return self.tokenizer.encode(s, add_special_tokens=False)
-        def tok_decode(self, t, **kw): return self.tokenizer.decode(t, skip_special_tokens=True)
+        def tok_encode(self, s, **kw):
+            return self.tokenizer.encode(s, add_special_tokens=False)
+
+        def tok_decode(self, t, **kw):
+            return self.tokenizer.decode(t, skip_special_tokens=True)
+
+        def tok_decode_with_tags(self, t):
+            """Decode keeping special tokens visible so we can parse tags."""
+            return self.tokenizer.decode(t, skip_special_tokens=False)
+
+        def extract_answer(self, raw_text: str) -> str:
+            """Pull the <|answer|>...<|/answer|> region out of raw model output.
+
+            For benchmarks the model is trained to emit reasoning inside
+            <|think|>...<|/think|> and the actual answer inside
+            <|answer|>...<|/answer|>. If we submit the full decoded text as
+            the response, strict benchmarks (e.g. IFEval format checks,
+            GSM8K answer extraction) see the reasoning mixed in with the
+            answer and usually mark it wrong.
+
+            Strategy:
+              1. If <|answer|> is present, take everything up to <|/answer|>
+                 (or EOS/end if no close tag).
+              2. Else, if <|/think|> is present, take everything after it.
+              3. Else, fall back to the raw text.
+            Then strip any remaining special token markers from the result.
+            """
+            ANS_OPEN = "<|answer|>"
+            ANS_CLOSE = "<|/answer|>"
+            THINK_CLOSE = "<|/think|>"
+
+            text = raw_text
+            if ANS_OPEN in text:
+                start = text.index(ANS_OPEN) + len(ANS_OPEN)
+                tail = text[start:]
+                if ANS_CLOSE in tail:
+                    tail = tail[: tail.index(ANS_CLOSE)]
+                extracted = tail
+            elif THINK_CLOSE in text:
+                extracted = text.split(THINK_CLOSE, 1)[1]
+            else:
+                extracted = text
+
+            # Strip any residual special-token markers the harness might
+            # otherwise interpret as content.
+            for tok in (
+                "<|begin_of_text|>", "<|end_of_text|>", "<|padding|>",
+                "<|user|>", "<|assistant|>", "<|system|>",
+                "<|think|>", "<|/think|>", ANS_OPEN, ANS_CLOSE,
+                "<|fim_prefix|>", "<|fim_middle|>", "<|fim_suffix|>",
+                "<|unknown|>",
+            ):
+                extracted = extracted.replace(tok, "")
+            return extracted.strip()
 
         def _model_call(self, inps):
             with torch.no_grad():
@@ -665,15 +727,27 @@ def evaluate(tasks: str = "ifeval", limit: int = 0):
                 ctx_t = torch.tensor([ctx_ids], dtype=torch.long)
                 if ctx_t.shape[1] > self.max_length - max_gen:
                     ctx_t = ctx_t[:, -(self.max_length - max_gen):]
-                out = self.model.generate(ctx_t.to(self._device), max_new_tokens=max_gen,
-                                          temperature=0.0, eos_token_id=self.tokenizer.eos_token_id)
-                resp = self.tok_decode(out[0, ctx_t.shape[1]:].tolist())
+                out = self.model.generate(
+                    ctx_t.to(self._device),
+                    max_new_tokens=max_gen,
+                    temperature=0.0,
+                    eos_token_id=self.tokenizer.eos_token_id,
+                )
+                new_ids = out[0, ctx_t.shape[1]:].tolist()
+
+                # Decode keeping the special tokens visible so we can
+                # extract <|answer|>...<|/answer|>. Strict benchmarks need
+                # ONLY the answer, not the reasoning prefix.
+                raw = self.tok_decode_with_tags(new_ids)
+                resp = self.extract_answer(raw)
+
+                # Also respect the harness-provided stop strings.
                 for stop in until:
-                    if stop in resp:
+                    if stop and stop in resp:
                         resp = resp[:resp.index(stop)]
                 results.append(resp)
-                if (i+1) % 50 == 0:
-                    print(f"  Generated {i+1}/{len(requests)}")
+                if (i + 1) % 50 == 0:
+                    print(f"  Generated {i + 1}/{len(requests)}")
             return results
 
     lm = V4EvalModel()

--- a/app_v4.py
+++ b/app_v4.py
@@ -1,11 +1,12 @@
 """NanoOSRT v4 — Modal deployment entrypoint.
 
-453M physical params, ~275M active/token, ~2.7B effective via recursive MoE.
+~356M physical params (64K vocab + 1536 dim), ~180M active/token,
+~2.1B effective via recursive weight sharing.
 3 physical blocks × 6 loops = 18 effective layers.
 Dense FFN + MoE (1 shared + 11 routed experts, top-2) in parallel residual.
 
 Stages:
-    modal run app_v4.py --stage tokenizer    Train custom 128K tokenizer
+    modal run app_v4.py --stage tokenizer    Train custom 64K BPE tokenizer
     modal run app_v4.py --stage pretrain     Pre-training (progressive seq_len)
     modal run app_v4.py --stage sft          Balanced SFT (math + code + STEM + general)
     modal run app_v4.py --stage grpo         GRPO reinforcement learning
@@ -318,6 +319,7 @@ def grpo():
 
         optimizer.zero_grad(set_to_none=True)
         step_loss = 0.0
+        step_kl = 0.0
         step_rewards = []
         step_correct = 0
         step_total = 0
@@ -363,16 +365,26 @@ def grpo():
                 completions.append(generated.squeeze(0))
             model.train()
 
-            # Score
+            # Score — IMPORTANT: skip_special_tokens=False so native tags
+            # like <|think|>, <|answer|> survive decoding for the reward
+            # scorer. And explicitly pass the v4 native tag strings so
+            # the reward function doesn't fall back to v3 defaults.
             rewards = []
             for comp_ids in completions:
-                comp_text = tok.decode(comp_ids[prompt_len:].tolist(), skip_special_tokens=True)
+                comp_text = tok.decode(
+                    comp_ids[prompt_len:].tolist(),
+                    skip_special_tokens=False,
+                )
                 comp_tokens = len(comp_ids) - prompt_len
                 reward, breakdown = compute_reward(
                     comp_text, ground_truth,
                     correctness_weight=cfg.correctness_reward,
                     format_weight=cfg.format_reward,
                     length_penalty=cfg.length_penalty,
+                    think_open=cfg.think_open,
+                    think_close=cfg.think_close,
+                    answer_open=cfg.answer_open,
+                    answer_close=cfg.answer_close,
                     max_tokens=cfg.max_gen_len,
                     completion_tokens=comp_tokens,
                     reasoning_bonus=cfg.reasoning_bonus,
@@ -395,28 +407,45 @@ def grpo():
                 if comp_len <= 0:
                     continue
 
-                # Policy log probs
+                # Policy log probs on the sampled completion
                 with torch.amp.autocast("cuda", dtype=torch.bfloat16):
                     out = model(comp_ids.unsqueeze(0))
                     logits = out.logits[0, :, :model_config.real_vocab_size].float()
                 shift_logits = logits[prompt_len - 1:-1]
                 shift_labels = comp_ids[prompt_len:]
-                policy_lp = F.log_softmax(shift_logits, dim=-1).gather(1, shift_labels.unsqueeze(1)).squeeze(1)
+                policy_lp = F.log_softmax(shift_logits, dim=-1).gather(
+                    1, shift_labels.unsqueeze(1)
+                ).squeeze(1)
 
+                # Reference log probs (frozen, no grad)
                 with torch.no_grad():
                     ref_out = ref_model(comp_ids.unsqueeze(0))
-                    ref_logits = ref_out.logits[0, :, :model_config.real_vocab_size].float()
+                    ref_logits = ref_out.logits[
+                        0, :, :model_config.real_vocab_size
+                    ].float()
                 ref_shift = ref_logits[prompt_len - 1:-1]
-                ref_lp = F.log_softmax(ref_shift, dim=-1).gather(1, shift_labels.unsqueeze(1)).squeeze(1)
+                ref_lp = F.log_softmax(ref_shift, dim=-1).gather(
+                    1, shift_labels.unsqueeze(1)
+                ).squeeze(1)
 
-                ratio = torch.exp(policy_lp - ref_lp)
-                clipped = torch.clamp(ratio, 1 - cfg.clip_range, 1 + cfg.clip_range)
+                # Direct policy gradient weighted by group-normalised advantage.
+                # Since we perform only one gradient step per sampled batch,
+                # importance-sampling ratio ~= 1, so PPO clipping is a no-op
+                # here. We keep the formulation simple and correct.
                 adv_t = torch.tensor(adv, device=device, dtype=torch.float32)
-                policy_loss = -torch.min(ratio * adv_t, clipped * adv_t).mean()
-                kl_loss = cfg.kl_coeff * (policy_lp - ref_lp).mean()
-                loss = (policy_loss + kl_loss) / cfg.grad_accum_steps
+                policy_loss = -(policy_lp * adv_t).mean()
+
+                # Schulman's unbiased non-negative KL approximation:
+                #   approx_kl = exp(ref_lp - policy_lp) - (ref_lp - policy_lp) - 1
+                # Always >= 0 (unlike the simple mean(policy_lp - ref_lp) which
+                # can go negative and give a bogus "negative KL" penalty).
+                log_ratio = ref_lp - policy_lp
+                approx_kl = (torch.exp(log_ratio) - log_ratio - 1).mean()
+
+                loss = (policy_loss + cfg.kl_coeff * approx_kl) / cfg.grad_accum_steps
                 loss.backward()
                 step_loss += loss.item()
+                step_kl += approx_kl.item()
 
         torch.nn.utils.clip_grad_norm_(model.parameters(), cfg.grad_clip)
         optimizer.step()
@@ -428,12 +457,19 @@ def grpo():
             elapsed = time.time() - start_time
             vram = torch.cuda.max_memory_allocated() / 1e9
             torch.cuda.reset_peak_memory_stats()
+            mean_kl = step_kl / max(step_total, 1)
             print(f"step {step:>6d}/{cfg.total_steps} | loss {step_loss:.4f} | "
                   f"reward {mean_reward:.3f} | acc {accuracy:.1%} | "
-                  f"lr {lr:.2e} | vram {vram:.1f}GB | elapsed {elapsed:.0f}s")
+                  f"kl {mean_kl:.4f} | lr {lr:.2e} | "
+                  f"vram {vram:.1f}GB | elapsed {elapsed:.0f}s")
             if use_wandb:
-                wandb.log({"grpo/loss": step_loss, "grpo/mean_reward": mean_reward,
-                           "grpo/accuracy": accuracy, "grpo/lr": lr}, step=step)
+                wandb.log({
+                    "grpo/loss": step_loss,
+                    "grpo/mean_reward": mean_reward,
+                    "grpo/accuracy": accuracy,
+                    "grpo/approx_kl": mean_kl,
+                    "grpo/lr": lr,
+                }, step=step)
 
         # Checkpoints
         if step > 0 and step % cfg.ckpt_interval == 0:
@@ -507,17 +543,57 @@ def evaluate(tasks: str = "ifeval", limit: int = 0):
 
             self.model = NanoOSRTv4ForCausalLM(model_config).to("cuda")
 
-            # Load latest checkpoint
+            # Resolve latest checkpoint: priority grpo_final > sft_final > final.
             import os
+
+            from nano_osrt.hra import inject_hra
+
             ckpt_dir = "/vol/checkpoints/v4"
-            # Priority: grpo_final > sft_final > final
-            for name in ["osrt_v4_grpo_final.pt", "osrt_v4_sft_final.pt", "osrt_v4_final.pt"]:
+            resolved_path = None
+            resolved_stage = None
+            for stage, name in [
+                ("grpo", "osrt_v4_grpo_final.pt"),
+                ("sft", "osrt_v4_sft_final.pt"),
+                ("pretrain", "osrt_v4_final.pt"),
+            ]:
                 path = os.path.join(ckpt_dir, name)
                 if os.path.exists(path):
-                    print(f"Loading {path}...")
-                    ckpt = torch.load(path, map_location="cuda", weights_only=True)
-                    self.model.load_state_dict(ckpt.get("model_state_dict", ckpt), strict=False)
+                    resolved_path = path
+                    resolved_stage = stage
                     break
+
+            if resolved_path is None:
+                raise FileNotFoundError(
+                    f"No v4 checkpoint found in {ckpt_dir}. "
+                    "Run pretrain/sft/grpo first."
+                )
+
+            print(f"Loading {resolved_path} (stage={resolved_stage})...")
+            ckpt = torch.load(resolved_path, map_location="cuda", weights_only=True)
+            state_dict = ckpt.get("model_state_dict", ckpt)
+
+            # SFT/GRPO checkpoints have HRA-wrapped linear layers (keys like
+            # 'blocks.0.qkv.adapter_a', 'blocks.0.qkv.original.weight').
+            # Inject HRA into a plain base model so the key names match,
+            # otherwise load_state_dict silently drops everything HRA-related.
+            if resolved_stage in ("sft", "grpo"):
+                has_hra_keys = any(
+                    "adapter_a" in k or "adapter_b" in k or "original.weight" in k
+                    for k in state_dict
+                )
+                if has_hra_keys:
+                    print("  Detected HRA keys in checkpoint, injecting adapters...")
+                    inject_hra(self.model, rank=256)
+
+            missing, unexpected = self.model.load_state_dict(
+                state_dict, strict=False
+            )
+            if missing:
+                print(f"  MISSING keys ({len(missing)}): sample {missing[:3]}")
+            if unexpected:
+                print(f"  UNEXPECTED keys ({len(unexpected)}): sample {unexpected[:3]}")
+            if not missing and not unexpected:
+                print("  Clean load: all keys matched.")
 
             self.model.eval()
             self.tokenizer = tok
@@ -631,7 +707,7 @@ def evaluate(tasks: str = "ifeval", limit: int = 0):
 def main(stage: str = "pretrain"):
     """Run v4 training stages.
 
-    --stage tokenizer  Train custom 128K tokenizer
+    --stage tokenizer  Train custom 64K BPE tokenizer
     --stage pretrain   Pre-training (progressive seq_len)
     --stage sft        Balanced SFT
     --stage grpo       GRPO reinforcement learning

--- a/docs/v4-architecture-plan.md
+++ b/docs/v4-architecture-plan.md
@@ -12,14 +12,14 @@ to dramatically increase model capacity while keeping active compute manageable.
 | Effective layers | 12 | 18 |
 | Dense FFN | Yes | Yes (kept) |
 | MoE FFN | No | 12 experts (1 shared + 11 routed, top-2) |
-| Physical params | 104.5M | ~356M |
-| Active params/token | 104.5M | ~180M |
-| Effective params (recursive) | ~302M | ~2.1B |
+| Physical params | 104.5M | ~306M |
+| Active params/token (body) | 104.5M | ~130M |
+| Block applications (recursive) | 12 | 18 |
 | HRA (post-training) | +11M | +15-20M |
 | Hidden dim | 1280 | 1536 |
 | Attention heads | 20 | 24 |
 | Head dim | 64 | 64 |
-| Tokenizer | GPT-NeoX (50K) | Custom 64K BPE |
+| Tokenizer | GPT-NeoX (50K) | Custom 32K BPE |
 | Seq len (training) | 2048 → 4096 | 2048 → 4096 → 8192 |
 | Seq len (inference) | 4096 | 16K+ (RoPE scaling) |
 
@@ -55,9 +55,8 @@ x = x + h_dense + h_moe
 
 ```
                     ┌─────────────┐
-                    │   Router    │ (dim → 11, softmax)
-                    │  + loop     │
-                    │  embedding  │
+                    │   Router    │ (dim → 11, sigmoid)
+                    │ x + loop_e  │
                     └──────┬──────┘
                            │ top-2 indices + weights
             ┌──────────────┼──────────────┐
@@ -74,10 +73,12 @@ x = x + h_dense + h_moe
 ```
 
 **Router design:**
-- Input: hidden state + learned loop embedding (loop-aware routing)
-- Output: softmax over 11 routed experts
-- Top-2 selection with load balancing auxiliary loss
+- Input: hidden state + learned loop embedding added together (loop-aware routing)
+- Output: independent sigmoid gates over 11 routed experts (DeepSeek-V3 style)
+- Top-2 selection with load-balancing auxiliary loss + router z-loss
 - Shared expert output added unconditionally
+- Dense FFN runs in parallel with gated contribution (dense_gate=1.0 init,
+  moe_gate=0.01 init so training starts near-pure-dense)
 
 **Expert architecture:**
 - Each expert is a small SwiGLU: dim → expert_hidden → dim

--- a/docs/v4-architecture-plan.md
+++ b/docs/v4-architecture-plan.md
@@ -29,27 +29,65 @@ to dramatically increase model capacity while keeping active compute manageable.
 
 ### 1.1 Block Structure
 
-Each of the 3 physical `RecursiveBlock` modules contains:
+Each of the 3 physical `RecursiveBlock` modules runs three parallel
+branches into a shared residual stream. The adapter is an additive
+parallel branch alongside attention — attention always reads the
+clean (un-adapted) residual, and the adapter contribution survives
+into downstream layers as part of the residual sum.
 
 ```
-Input
-  ├── RMSNorm → Per-pass adapter → Causal Attention (RoPE) → Residual
-  ├── RMSNorm → Dense SwiGLU FFN → Residual
-  └── RMSNorm → MoE FFN (shared + top-2 routed) → Residual
+                    x  ──┬─────────────┐
+                         │             │
+         ┌───────────────┤        adapter_out =
+         │               │        scale * (x @ A @ B)
+     RMSNorm             │             │
+         │               │             │
+     Attention           │             │
+  (QKV + RoPE + SDPA)    │             │
+         │               │             │
+     out_proj ───────────┘             │
+                         │             │
+                         │  x = x + attn_out + adapter_out
+                         │             │
+                         │             ▼
+                         │       (block residual)
+                         │             │
+           ┌─────────────┴─────────────┤
+           │                           │
+       RMSNorm                     RMSNorm
+           │                           │
+     Dense SwiGLU              MoE FFN (loop-aware)
+           │                           │
+           ▼                           ▼
+   dense_gate=1.0            moe_gate=0.01 (init)
+         (1.0) × h_dense     (0.01) × h_moe
+           │                           │
+           └──────────┬────────────────┘
+                      ▼
+         x = x + dense_gate * h_dense
+               + moe_gate   * h_moe
 ```
 
-The dense FFN and MoE FFN run in **parallel residual** paths:
-
+Pseudocode:
 ```python
-# Dense path (always active, full capacity)
-h_dense = self.ffn_dense(self.norm_dense(x))
+# Additive parallel adapter — attention reads the clean x
+adapter_out = scale * (x @ A @ B)
+attn_out = attention(norm_attn(x))
+x = x + out_proj(attn_out) + adapter_out
 
-# Sparse MoE path (shared expert + top-2 routed)
-h_moe = self.moe(self.norm_moe(x))
-
-# Combined residual
-x = x + h_dense + h_moe
+# Parallel dense + MoE FFN with learnable gates
+h_dense = ffn_dense(norm_dense(x))
+h_moe   = moe(norm_moe(x), loop_idx)
+x = x + dense_gate * h_dense + moe_gate * h_moe
 ```
+
+Key choices:
+- Adapter as parallel branch (not pre-attention shift) — attention
+  never has to compensate for a random-init adapter direction.
+- `moe_gate = 0.01` at init — model starts near-pure-dense and
+  gradually blends in the MoE path as the router and experts
+  specialise. Avoids destabilising early training with random MoE
+  contributions before the router has learned anything useful.
 
 ### 1.2 MoE Layer
 
@@ -101,28 +139,36 @@ x = x + h_dense + h_moe
 
 | Component | Params |
 |-----------|--------|
-| Token embedding (32K × 1536) | 49.2M |
+| Token embedding (32K × 1536) | 50.3M |
 | Blocks (3) | 254.8M |
 | Per-pass adapters (18 × rank 16) | 0.88M |
-| Norm layers (loop + output) | 3.1K |
-| Router weights (3 blocks × 11) | ~50K |
-| **Total physical** | **~305M** |
-| **Active per token** | **~155M** |
-| **Effective (recursive ×6)** | **~930M** |
+| Norm layers (loop + output) | ~3K |
+| Router weights (3 × 11 × 1536) | ~50K |
+| Loop embeddings (6 × 1536) | ~9K |
+| Dense/MoE gates (6 scalars) | 6 |
+| **Total physical**            | **~306M** |
+| **Active transformer body**   | **~130M** per-token compute (excl. embedding lookup) |
+| **Block applications**        | **6** (via recursive weight sharing) |
 
-> Note: Physical params are higher than 200M target. Options to reduce:
-> - Reduce to 8 experts (saves ~60M)
-> - Reduce expert hidden to 768 (saves ~40M)
-> - Reduce dim to 1408 (saves ~30M across everything)
-> - Drop to 2 blocks (back to v3 structure, saves ~85M)
+### Parameter accounting notes
 
-**Recommended trim: 8 routed experts + 1 shared = 9 total, expert hidden 896:**
-
-| | 12 experts | 9 experts (trimmed) |
-|--|-----------|-------------------|
-| Physical | ~305M | ~220M |
-| Active/token | ~155M | ~135M |
-| Effective | ~930M | ~810M |
+- "Effective params" is **not** the same as a dense model with that many
+  independent weights. The model has 306M unique parameters; each
+  forward runs the transformer body ~6 times with distinct per-pass
+  adapters and loop-conditioned routing. Think of the 1.8B "effective"
+  number as the **per-token compute budget**, not as memorisation
+  capacity.
+- **Active per token** is what determines inference speed. Only the
+  shared expert plus 2 of 11 routed experts run per token per loop,
+  so even though the routed pool is 156M, only ~28M of it is used per
+  token (top-2 of 11 ≈ 18% of expert params). Plus dense FFN (57M),
+  attention (28M), and shared expert (14M), giving ~130M transformer
+  body compute per token per block application.
+- **Why this is interesting**: 130M active / 306M physical is a 43%
+  activation ratio — tight, which gives the model specialised capacity
+  without exploding inference cost. Compared to a dense 306M model,
+  v4 gets an additional 162M of specialist weights "for free" in terms
+  of per-token inference FLOPs.
 
 ### 1.4 Tokenizer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = [
     "langdetect>=1.0.9",
     "immutabledict>=4.3.1",
     "gradio>=6.9.0",
+    "wandb>=0.25.1",
+    "pandas>=3.0.1",
 ]
 
 [project.scripts]

--- a/scripts/train_tokenizer.py
+++ b/scripts/train_tokenizer.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Train a custom 64K SuperBPE tokenizer for NanoOSRT v4.
+"""Train a custom 32K BPE tokenizer for NanoOSRT v4.
 
-Uses the SuperBPE two-stage process:
-  Stage 1: Standard BPE with whitespace pretokenization (learns subwords)
-  Stage 2: Continue training without pretokenization (learns superwords)
+Default uses HuggingFace byte-level BPE. Optionally falls through to
+SuperBPE (COLM 2025) if the 'superbpe' package is installed for the
+two-stage subwords → superwords curriculum, which produces ~33% fewer
+tokens and +4% on benchmarks vs standard BPE.
 
-SuperBPE produces 33% fewer tokens and +4% on benchmarks vs standard BPE (COLM 2025).
-
-Training data: sampled from the pre-training mix (FineWeb-Edu + StarCoder + Wikipedia)
-to ensure the tokenizer is optimized for our exact distribution.
+Training data: sampled from the pre-training mix (FineWeb-Edu +
+CodeParrot-clean + Wikipedia) to ensure the tokenizer is optimised for
+the exact distribution the model will see during pretraining.
 
 Usage:
     # Full training (~2-4 hours on CPU, ~30 min on GPU)
@@ -302,7 +302,7 @@ def _verify_tokenizer(output_dir: str) -> None:
 
 def main():
     parser = argparse.ArgumentParser(description="Train custom 64K tokenizer for NanoOSRT v4")
-    parser.add_argument("--vocab-size", type=int, default=65536, help="Target vocabulary size (64K default, TC-aligned)")
+    parser.add_argument("--vocab-size", type=int, default=32768, help="Target vocabulary size (32K default, TC-aligned)")
     parser.add_argument("--sample-size", type=int, default=50_000_000, help="Training text size in chars (~50MB default)")
     parser.add_argument("--output", type=str, default="./tokenizer-v4", help="Output directory")
     parser.add_argument("--data-path", type=str, default=None, help="Pre-existing training text file (skip download)")

--- a/scripts/train_tokenizer.py
+++ b/scripts/train_tokenizer.py
@@ -37,16 +37,24 @@ except ImportError:
     pass
 
 
-def sample_training_data(sample_size: int = 50_000_000, seed: int = 42) -> str:
+def sample_training_data(sample_size: int = 2_000_000_000, seed: int = 42) -> str:
     """Sample training data from pre-training mix and save to temp file.
 
     Samples proportionally:
       - 55% FineWeb-Edu (general text)
-      - 30% StarCoder Python (code)
+      - 30% CodeParrot Clean (code)
       - 15% Wikipedia (factual/STEM)
 
+    For a 32K BPE tokenizer, ~2GB of training data is the sweet spot —
+    larger samples hit diminishing returns on merge quality and expose
+    us to more HF Hub network issues.
+
+    Resilient to transient HF Hub connection drops: if a source fails
+    partway through, we log the partial collection and move on to the
+    next source instead of aborting the whole run.
+
     Args:
-        sample_size: Target number of characters to sample.
+        sample_size: Target number of characters to sample (default 2GB).
         seed: Random seed.
 
     Returns:
@@ -78,33 +86,120 @@ def sample_training_data(sample_size: int = 50_000_000, seed: int = 42) -> str:
         },
     ]
 
+    def _log(msg: str) -> None:
+        """Print with explicit flush so Modal log tail stays live."""
+        print(msg, flush=True)
+
+    def _stream_with_retry(src: dict, target_chars: int) -> int:
+        """Stream from one source, retrying on transient errors.
+
+        Logs progress every ~10MB and on every retry so the run is never
+        silent. Returns the number of characters successfully written.
+        """
+        max_attempts = 3
+        collected = 0
+        last_error = None
+        # Log roughly every 10MB of accumulated text.
+        progress_every = 10_000_000
+        next_progress_at = progress_every
+        src_start = time.time()
+
+        for attempt in range(1, max_attempts + 1):
+            if collected >= target_chars:
+                break
+            try:
+                load_kwargs = {"split": "train", "streaming": True}
+                if "hf_config" in src:
+                    load_kwargs["name"] = src["hf_config"]
+
+                _log(
+                    f"    [{src['name']}] attempt {attempt}/{max_attempts}: "
+                    f"opening stream..."
+                )
+                ds = load_dataset(src["hf_id"], **load_kwargs)
+                ds = ds.shuffle(buffer_size=10_000, seed=seed + attempt)
+                _log(f"    [{src['name']}] stream ready, reading examples...")
+
+                examples_seen = 0
+                for example in ds:
+                    examples_seen += 1
+                    text = example.get(src["text_key"], "")
+                    if not text or len(text) < 100:
+                        continue
+                    tmp.write(text + "\n")
+                    collected += len(text)
+
+                    if collected >= next_progress_at:
+                        elapsed = time.time() - src_start
+                        mb = collected / 1e6
+                        pct = collected / target_chars * 100
+                        rate = mb / elapsed if elapsed > 0 else 0
+                        _log(
+                            f"    [{src['name']}] {mb:.0f} MB "
+                            f"({pct:.1f}% of target, "
+                            f"{examples_seen:,} examples read, "
+                            f"{rate:.1f} MB/s, {elapsed:.0f}s elapsed)"
+                        )
+                        next_progress_at += progress_every
+
+                    if collected >= target_chars:
+                        break
+                # Clean exit — loop terminated because we hit target or
+                # the stream ended naturally.
+                elapsed = time.time() - src_start
+                _log(
+                    f"    [{src['name']}] stream finished at {collected / 1e6:.0f} MB "
+                    f"({examples_seen:,} examples, {elapsed:.0f}s)"
+                )
+                return collected
+            except Exception as e:
+                last_error = e
+                pct = collected / target_chars * 100 if target_chars else 0
+                _log(
+                    f"    [{src['name']}] attempt {attempt}/{max_attempts} "
+                    f"hit {type(e).__name__}: {str(e)[:120]}"
+                )
+                _log(
+                    f"    [{src['name']}] {collected / 1e6:.0f} MB collected so far "
+                    f"({pct:.0f}% of target), retrying from fresh stream..."
+                )
+
+        if last_error and collected < target_chars:
+            pct = collected / target_chars * 100 if target_chars else 0
+            _log(
+                f"    [{src['name']}] giving up after {max_attempts} attempts "
+                f"({collected / 1e6:.0f} MB, {pct:.0f}% of target)"
+            )
+        return collected
+
+    sample_start = time.time()
+    _log(f"  Target: {sample_size:,} chars ({sample_size / 1e9:.1f} GB)")
+
     total_chars = 0
     for src in sources:
         target_chars = int(sample_size * src["fraction"])
-        chars = 0
-
-        print(f"  Sampling {src['name']} ({target_chars:,} chars target)...")
-        load_kwargs = {"split": "train", "streaming": True}
-        if "hf_config" in src:
-            load_kwargs["name"] = src["hf_config"]
-
-        ds = load_dataset(src["hf_id"], **load_kwargs)
-        ds = ds.shuffle(buffer_size=10_000, seed=seed)
-
-        for example in ds:
-            text = example.get(src["text_key"], "")
-            if not text or len(text) < 100:
-                continue
-            tmp.write(text + "\n")
-            chars += len(text)
-            if chars >= target_chars:
-                break
-
-        total_chars += chars
-        print(f"    Collected {chars:,} chars")
+        _log(
+            f"  Sampling {src['name']} "
+            f"({target_chars:,} chars target, {target_chars / 1e9:.2f} GB)..."
+        )
+        got = _stream_with_retry(src, target_chars)
+        total_chars += got
+        _log(f"    Collected {got:,} chars from {src['name']}")
 
     tmp.close()
-    print(f"  Total: {total_chars:,} chars -> {tmp.name}")
+    elapsed = time.time() - sample_start
+    _log(
+        f"  Sampling complete: {total_chars:,} chars "
+        f"({total_chars / 1e9:.2f} GB) in {elapsed:.0f}s -> {tmp.name}"
+    )
+
+    if total_chars < 100_000_000:  # <100MB is too little even for 32K BPE
+        raise RuntimeError(
+            f"Sampling produced only {total_chars:,} chars (<100MB). "
+            "Network to HF Hub is probably broken. Retry later or "
+            "lower the target further."
+        )
+
     return tmp.name
 
 
@@ -123,8 +218,8 @@ def train_with_hf_tokenizers(data_path: str, vocab_size: int, output_dir: str) -
         trainers,
     )
 
-    print("\nTraining BPE tokenizer with HuggingFace tokenizers...")
-    print(f"  Vocab size: {vocab_size:,}")
+    print("\nTraining BPE tokenizer with HuggingFace tokenizers...", flush=True)
+    print(f"  Vocab size: {vocab_size:,}", flush=True)
 
     # BPE model with byte fallback
     tokenizer = Tokenizer(models.BPE())
@@ -159,10 +254,17 @@ def train_with_hf_tokenizers(data_path: str, vocab_size: int, output_dir: str) -
         initial_alphabet=pre_tokenizers.ByteLevel.alphabet(),
     )
 
-    print("  Training (this may take a while)...")
+    # Report sample size in MB so the user can estimate training time.
+    import os as _os
+    sample_mb = _os.path.getsize(data_path) / 1e6
+    print(
+        f"  Training on {sample_mb:.0f} MB of text "
+        f"(this usually takes 2-10 min depending on CPU speed)...",
+        flush=True,
+    )
     t0 = time.time()
     tokenizer.train([data_path], trainer)
-    print(f"  Training done in {time.time() - t0:.0f}s")
+    print(f"  Training done in {time.time() - t0:.0f}s", flush=True)
 
     # Post-processor: add BOS/EOS
     tokenizer.post_processor = processors.TemplateProcessing(

--- a/src/nano_osrt/rewards.py
+++ b/src/nano_osrt/rewards.py
@@ -11,22 +11,36 @@ Uses rule-based rewards (no learned reward model):
 import re
 
 
-def extract_numeric_answer(text: str) -> str | None:
+def extract_numeric_answer(
+    text: str,
+    think_close: str = "</think>",
+    answer_open: str = "<|answer|>",
+    answer_close: str = "<|/answer|>",
+) -> str | None:
     """Extract the final numeric answer from model output.
 
-    Looks for the answer after </think> tag, or falls back to
-    the last number in the text.
+    Priority order:
+        1. Content between answer_open / answer_close tags (v4 native tags)
+        2. First number after think_close (v3 format)
+        3. Last number in the entire text (fallback)
     """
-    # Try to get answer after </think>
-    think_split = text.split("</think>")
-    if len(think_split) > 1:
-        after_think = think_split[-1].strip()
-        # Find numbers (including negatives, decimals, commas)
+    # Strategy 1: look inside explicit answer tags
+    if answer_open in text and answer_close in text:
+        start = text.index(answer_open) + len(answer_open)
+        end = text.index(answer_close, start) if answer_close in text[start:] else len(text)
+        inside = text[start:end]
+        numbers = re.findall(r"-?[\d,]+\.?\d*", inside)
+        if numbers:
+            return numbers[0].replace(",", "")
+
+    # Strategy 2: first number after the think_close tag
+    if think_close and think_close in text:
+        after_think = text.split(think_close, 1)[1].strip()
         numbers = re.findall(r"-?[\d,]+\.?\d*", after_think)
         if numbers:
             return numbers[0].replace(",", "")
 
-    # Fallback: last number in entire text
+    # Strategy 3: fallback to last number in entire text
     numbers = re.findall(r"-?[\d,]+\.?\d*", text)
     if numbers:
         return numbers[-1].replace(",", "")
@@ -100,6 +114,8 @@ def compute_reward(
     length_penalty: float = 0.0,
     think_open: str = "<think>",
     think_close: str = "</think>",
+    answer_open: str = "<|answer|>",
+    answer_close: str = "<|/answer|>",
     max_tokens: int = 0,
     completion_tokens: int = 0,
     reasoning_bonus: float = 0.3,
@@ -110,11 +126,15 @@ def compute_reward(
 
     Reward components:
         1. Correctness (+1.0): correct final answer
-        2. Format (+0.2): proper <think>...</think> tags
+        2. Format (+0.2): proper think_open/think_close tags present
         3. Reasoning bonus (+0.3): multi-step thinking when correct
         4. Truncation penalty (-0.5): output hit 90% of max tokens
-        5. Empty thinking penalty (-0.1): <think></think> with no content
+        5. Empty thinking penalty (-0.1): thinking block has no content
         6. Length penalty (0.0 default): disabled, reasoning needs room
+
+    IMPORTANT: pass the actual tag strings used during training (e.g. v4 uses
+    single-token native tags '<|think|>' and '<|/think|>'). The defaults match
+    v3's plain-string tags and will silently fail for v4 if not overridden.
 
     Returns:
         (total_reward, reward_breakdown_dict)
@@ -123,7 +143,12 @@ def compute_reward(
     breakdown = {}
 
     # 1. Correctness reward (core signal)
-    predicted = extract_numeric_answer(completion)
+    predicted = extract_numeric_answer(
+        completion,
+        think_close=think_close,
+        answer_open=answer_open,
+        answer_close=answer_close,
+    )
     gt = extract_gsm8k_answer(ground_truth_answer)
     if gt is None:
         gt = ground_truth_answer.replace(",", "").strip()

--- a/src/nano_osrt/v4_config.py
+++ b/src/nano_osrt/v4_config.py
@@ -11,12 +11,13 @@ from transformers import PretrainedConfig
 class NanoOSRTv4Config(PretrainedConfig):
     """HuggingFace-compatible config for NanoOSRT v4.
 
-    Architecture: ~356M physical params, ~180M active per token,
-    ~2.1B effective via recursive weight sharing.
+    Architecture: ~306M physical params, ~130M active per token,
+    ~1.8B effective via recursive weight sharing.
 
-    64K vocab with dim=1536 uses ~101M params for embeddings (28%
-    of model). The remaining 255M powers the transformer body
-    including attention, dense FFN, and MoE experts.
+    32K vocab with dim=1536 uses ~50M params for embeddings (16%
+    of model). The remaining 256M powers the transformer body
+    including attention, dense FFN, and MoE experts — more of the
+    parameter budget goes to reasoning capacity vs embedding lookup.
     """
 
     model_type = "nano-osrt-v4"
@@ -27,8 +28,8 @@ class NanoOSRTv4Config(PretrainedConfig):
         dim: int = 1536,
         heads: int = 24,
         head_dim: int = 64,
-        vocab_size: int = 65536,   # 64K vocab — balances tokenisation quality vs param budget
-        real_vocab_size: int = 65536,
+        vocab_size: int = 32768,   # 32K vocab — more of the budget in the transformer body
+        real_vocab_size: int = 32768,
 
         # Recursive structure
         num_blocks: int = 3,

--- a/src/nano_osrt/v4_config.py
+++ b/src/nano_osrt/v4_config.py
@@ -53,11 +53,14 @@ class NanoOSRTv4Config(PretrainedConfig):
         router_z_loss_coeff: float = 0.01,
         # Router noise: additive Gaussian on router logits before top-k
         # during training. Breaks deterministic tie-locking at init when
-        # all sigmoid probs are near 0.5. std=0.3 relative to logit std ~0.78
-        # at init gives ~40% perturbation, more than enough to diversify
-        # top-k selections while staying small vs learned logits late in
-        # training.
-        router_noise_std: float = 0.3,
+        # all sigmoid probs are near 0.5. Starts at router_noise_std_init
+        # and decays linearly to router_noise_std_final over
+        # router_noise_anneal_steps. By the end of warmup the router is
+        # on its own and training-time assign_H reflects learned routing,
+        # not randomness.
+        router_noise_std_init: float = 0.3,
+        router_noise_std_final: float = 0.02,
+        router_noise_anneal_steps: int = 5000,
         # Loop embedding init std — raised from the default initializer_range
         # (0.02) so that x + loop_emb actually produces per-loop routing
         # differentiation at init. At 0.02, loop_emb contribution to router
@@ -109,7 +112,9 @@ class NanoOSRTv4Config(PretrainedConfig):
         self.expert_hidden = expert_hidden
         self.router_aux_loss_coeff = router_aux_loss_coeff
         self.router_z_loss_coeff = router_z_loss_coeff
-        self.router_noise_std = router_noise_std
+        self.router_noise_std_init = router_noise_std_init
+        self.router_noise_std_final = router_noise_std_final
+        self.router_noise_anneal_steps = router_noise_anneal_steps
         self.loop_embedding_init_std = loop_embedding_init_std
 
         self.max_position_embeddings = max_position_embeddings

--- a/src/nano_osrt/v4_config.py
+++ b/src/nano_osrt/v4_config.py
@@ -46,20 +46,112 @@ class NanoOSRTv4Config(PretrainedConfig):
         num_routed_experts: int = 11,
         top_k_experts: int = 2,
         expert_hidden: int = 1024,
-        # Stronger regularization to prevent the top-2 collapse we saw in
-        # the first v4 sanity run (expert_max_mean ~0.5 at step 200 while
-        # router_prob_entropy was still near-uniform).
+        # --- Routing regularisation (differentiable) ---
+        # Hard top-k is a non-differentiable gate; any balance loss computed
+        # from hard-assignment fractions saturates once experts die. We use
+        # a differentiable surrogate from the softmax router distribution
+        # instead: the "importance" loss
+        #     N * sum(importance^2) with importance = softmax_probs.mean(seq).
+        # Minimum 1.0 when uniform, grows quadratically with concentration.
+        #
+        # NOTE: We originally also used logit_bias (mean-centered logit
+        # squared deviation) and z_loss (squared logits) as extra guards.
+        # Sanity run showed these are actively harmful: they have a global
+        # minimum at logit=0, so during soft warmup they drive every router
+        # output to zero magnitude. A zero-logit router has no token-
+        # dependent preference, so the blend→hard transition finds nothing
+        # for top-k to grab onto and collapses immediately.
+        #
+        # Row-normed router init already addresses the global ordering
+        # concern at step 0, and the task loss punishes misrouting. The
+        # importance loss alone is enough to prevent marginal collapse
+        # while leaving the router free to develop opinions.
         router_aux_loss_coeff: float = 0.05,
-        router_z_loss_coeff: float = 0.01,
-        # Router noise: additive Gaussian on router logits before top-k
-        # during training. Breaks deterministic tie-locking at init when
-        # all sigmoid probs are near 0.5. Starts at router_noise_std_init
-        # and decays linearly to router_noise_std_final over
-        # router_noise_anneal_steps. By the end of warmup the router is
-        # on its own and training-time assign_H reflects learned routing,
-        # not randomness.
-        router_noise_std_init: float = 0.3,
-        router_noise_std_final: float = 0.02,
+        router_logit_bias_coeff: float = 0.0,
+        router_z_loss_coeff: float = 0.0,
+        # Softmax temperature for the differentiable balance losses and
+        # for soft-routing dispatch. Separate from sigmoid-gating scale.
+        router_softmax_temperature: float = 1.0,
+        # --- Soft→hard routing schedule ---
+        # The hard top-k winner-takes-all pattern self-reinforces from
+        # the very first step; even tiny initial logit differences become
+        # permanent winners. Bootstrap by running every routed expert
+        # every step (soft dispatch, softmax-weighted sum) for the first
+        # soft_warmup_steps, then blend into hard top-k linearly over
+        # blend_anneal_steps so dead experts never get a chance to form.
+        soft_warmup_steps: int = 500,
+        blend_anneal_steps: int = 500,
+        # --- Gumbel-top-k selection ---
+        # Deterministic top-k lets tiny logit ordering differences lock in
+        # permanent winners. First sanity run confirmed this: even after
+        # we removed the zero-logit pressure (z_loss, logit_bias), the
+        # shadow hard-top-k collapsed within 40 steps because task loss
+        # kept rewarding whichever experts happened to score highest on
+        # the first few batches.
+        #
+        # Fix: during training, add Gumbel(0, tau) noise to router logits
+        # BEFORE the top-k operation. The selected *weights* still come
+        # from the clean sigmoid of the original logits, so gradient flow
+        # to the chosen experts is undisturbed. Only the *selection*
+        # becomes stochastic — which breaks deterministic winner lock-in
+        # because no expert is guaranteed to be picked by tie-breaking.
+        #
+        # tau anneals linearly from router_gumbel_tau_init down to
+        # router_gumbel_tau_final over router_gumbel_anneal_steps. At
+        # step 0 of hard phase the noise magnitude should still be
+        # meaningful (tau=1.0 matches raw logit scale once logits are
+        # ~order 1). By the end of the anneal window the router is on
+        # its own and should have learned robust token-dependent
+        # preferences that top-k picks consistently even without noise.
+        # Long anneal: Gumbel noise is NOT a short warmup jitter; it's
+        # anti-lock-in pressure the router needs for as long as it takes
+        # to learn robust preferences. 10K steps holds the noise through
+        # most of the Foundation phase so the router has time to
+        # accumulate token-dependent gradient without getting locked
+        # into early winners. Final value is 0 so the production
+        # inference path is deterministic.
+        router_gumbel_tau_init: float = 0.0,
+        router_gumbel_tau_final: float = 0.0,
+        router_gumbel_anneal_steps: int = 10000,
+        # --- Balance-bias controller (DeepSeek-V3 style) ---
+        # Per-expert additive bias applied to router logits *as part of
+        # the routing mechanism* (both training and inference). The bias
+        # is updated per step by an additive controller:
+        #     delta = current_assignment_fraction - 1/N
+        #     bias -= update_rate * delta
+        #     bias = clamp(bias, -max, +max)
+        # Over-used experts get their logits pushed down; under-used
+        # experts get theirs pushed up. This directly attacks the
+        # failure mode we saw in the Gumbel run: soft-dispatch + Gumbel
+        # could keep noisy training healthy but the clean logit ordering
+        # still collapsed because task loss kept rewarding whichever
+        # experts scored highest. The bias counter-rotates the ordering
+        # whenever the assignment distribution deviates from uniform.
+        #
+        # Because the bias is part of the routing mechanism (persistent
+        # buffer, applied in eval too), "clean biased top-k" is the new
+        # inference health metric. Raw un-biased top-k is kept only as
+        # a diagnostic — its collapse is acceptable as long as biased
+        # routing remains balanced.
+        router_balance_bias_enabled: bool = False,
+        router_balance_bias_update_rate: float = 0.25,
+        router_balance_bias_ema_rate: float = 0.05,
+        router_balance_bias_max: float = 2.0,
+        # --- Capacity-capped routing ---
+        # Structural load balancing: each expert has a hard token cap
+        # per batch. For each token, scan candidates in descending
+        # router score and assign the first top_k experts that still
+        # have capacity. Guarantees bounded max by construction.
+        # candidate_k = num_routed is cheap (11 experts, 11 scans) and
+        # ensures tokens can always fall through to underused experts
+        # outside their top-6 preference list when the popular ones
+        # are full. Overflow should be near zero with candidate_k=11.
+        router_capacity_capped: bool = True,
+        router_candidate_k: int = 11,
+        router_capacity_factor: float = 1.25,
+        # --- Router noise (legacy, optional) ---
+        router_noise_std_init: float = 0.0,
+        router_noise_std_final: float = 0.0,
         router_noise_anneal_steps: int = 5000,
         # Loop embedding init std — raised from the default initializer_range
         # (0.02) so that x + loop_emb actually produces per-loop routing
@@ -111,7 +203,21 @@ class NanoOSRTv4Config(PretrainedConfig):
         self.top_k_experts = top_k_experts
         self.expert_hidden = expert_hidden
         self.router_aux_loss_coeff = router_aux_loss_coeff
+        self.router_logit_bias_coeff = router_logit_bias_coeff
         self.router_z_loss_coeff = router_z_loss_coeff
+        self.router_softmax_temperature = router_softmax_temperature
+        self.soft_warmup_steps = soft_warmup_steps
+        self.blend_anneal_steps = blend_anneal_steps
+        self.router_gumbel_tau_init = router_gumbel_tau_init
+        self.router_gumbel_tau_final = router_gumbel_tau_final
+        self.router_gumbel_anneal_steps = router_gumbel_anneal_steps
+        self.router_capacity_capped = router_capacity_capped
+        self.router_candidate_k = router_candidate_k
+        self.router_capacity_factor = router_capacity_factor
+        self.router_balance_bias_enabled = router_balance_bias_enabled
+        self.router_balance_bias_update_rate = router_balance_bias_update_rate
+        self.router_balance_bias_ema_rate = router_balance_bias_ema_rate
+        self.router_balance_bias_max = router_balance_bias_max
         self.router_noise_std_init = router_noise_std_init
         self.router_noise_std_final = router_noise_std_final
         self.router_noise_anneal_steps = router_noise_anneal_steps

--- a/src/nano_osrt/v4_config.py
+++ b/src/nano_osrt/v4_config.py
@@ -46,8 +46,23 @@ class NanoOSRTv4Config(PretrainedConfig):
         num_routed_experts: int = 11,
         top_k_experts: int = 2,
         expert_hidden: int = 1024,
-        router_aux_loss_coeff: float = 0.01,
-        router_z_loss_coeff: float = 0.001,
+        # Stronger regularization to prevent the top-2 collapse we saw in
+        # the first v4 sanity run (expert_max_mean ~0.5 at step 200 while
+        # router_prob_entropy was still near-uniform).
+        router_aux_loss_coeff: float = 0.05,
+        router_z_loss_coeff: float = 0.01,
+        # Router noise: additive Gaussian on router logits before top-k
+        # during training. Breaks deterministic tie-locking at init when
+        # all sigmoid probs are near 0.5. std=0.3 relative to logit std ~0.78
+        # at init gives ~40% perturbation, more than enough to diversify
+        # top-k selections while staying small vs learned logits late in
+        # training.
+        router_noise_std: float = 0.3,
+        # Loop embedding init std — raised from the default initializer_range
+        # (0.02) so that x + loop_emb actually produces per-loop routing
+        # differentiation at init. At 0.02, loop_emb contribution to router
+        # logits is ~0.016 vs ~0.78 from x → effectively invisible.
+        loop_embedding_init_std: float = 0.1,
 
         # Sequence length
         max_position_embeddings: int = 8192,
@@ -94,6 +109,8 @@ class NanoOSRTv4Config(PretrainedConfig):
         self.expert_hidden = expert_hidden
         self.router_aux_loss_coeff = router_aux_loss_coeff
         self.router_z_loss_coeff = router_z_loss_coeff
+        self.router_noise_std = router_noise_std
+        self.loop_embedding_init_std = loop_embedding_init_std
 
         self.max_position_embeddings = max_position_embeddings
         self.rope_theta = rope_theta

--- a/src/nano_osrt/v4_data.py
+++ b/src/nano_osrt/v4_data.py
@@ -5,9 +5,12 @@ Handles:
 - Multi-dataset weighted sampling within each phase
 - Code + text mixing from the start
 - Instruction format handling (messages column)
+- Resilient streaming: connection drops and corrupt shards are caught
+  and retried instead of killing the training run.
 """
 
 import random
+import time
 
 import torch
 from torch import Tensor
@@ -71,24 +74,59 @@ class V4TokenStream(IterableDataset):
 
         buffer: list[int] = []
 
+        def _reconnect_stream(stream_idx: int) -> None:
+            ds_cfg = self.dataset_configs[stream_idx]
+            load_kwargs = {"split": "train", "streaming": True}
+            if ds_cfg.get("hf_config"):
+                load_kwargs["name"] = ds_cfg["hf_config"]
+            ds = load_dataset(ds_cfg["hf_id"], **load_kwargs)
+            ds = ds.shuffle(
+                buffer_size=5_000,
+                seed=seed + rng.randint(0, 100_000),
+            )
+            streams[stream_idx] = iter(ds)
+            print(
+                f"[DataWorker] Reconnected to {ds_cfg['hf_id']}",
+                flush=True,
+            )
+
+        max_retries = 5
+
         while True:
-            # Weighted random dataset selection
             idx = rng.choices(range(len(streams)), weights=weights, k=1)[0]
+            ds_name = self.dataset_configs[idx].get("name", self.dataset_configs[idx]["hf_id"])
 
             try:
                 example = next(streams[idx])
             except StopIteration:
-                # Reload exhausted stream
-                ds_cfg = self.dataset_configs[idx]
-                load_kwargs = {"split": "train", "streaming": True}
-                if ds_cfg.get("hf_config"):
-                    load_kwargs["name"] = ds_cfg["hf_config"]
-                ds = load_dataset(ds_cfg["hf_id"], **load_kwargs)
-                ds = ds.shuffle(buffer_size=5_000, seed=seed + rng.randint(0, 10000))
-                streams[idx] = iter(ds)
+                _reconnect_stream(idx)
                 try:
                     example = next(streams[idx])
                 except StopIteration:
+                    continue
+            except Exception as exc:
+                # Connection drops, corrupt shards, HTTP errors —
+                # log, sleep, reconnect, and continue. A flaky remote
+                # gzip shard should never kill a multi-hour Modal job.
+                for attempt in range(1, max_retries + 1):
+                    print(
+                        f"[DataWorker] {ds_name}: {type(exc).__name__}: "
+                        f"{exc} — reconnecting [{attempt}/{max_retries}]",
+                        flush=True,
+                    )
+                    time.sleep(2 * attempt)
+                    try:
+                        _reconnect_stream(idx)
+                        example = next(streams[idx])
+                        break
+                    except Exception as retry_exc:
+                        exc = retry_exc
+                else:
+                    print(
+                        f"[DataWorker] {ds_name}: giving up after "
+                        f"{max_retries} retries, skipping batch",
+                        flush=True,
+                    )
                     continue
 
             # Extract text from example

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -23,6 +23,8 @@ as iterative refinement on a fixed parameter budget, not a 1:1 substitute
 for a dense 1.8B model.
 """
 
+import math
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -102,16 +104,31 @@ class ExpertFFN(nn.Module):
 
 
 class MoELayer(nn.Module):
-    """Mixture of Experts with shared expert + top-k routing.
+    """Mixture of Experts with shared expert + soft→hard top-k routing.
 
     Architecture:
         - 1 shared expert (always active, unconditional)
-        - N routed experts (top-k selected per token)
-        - Loop-aware router: receives hidden state + loop embedding
-        - Sigmoid gating (DeepSeek-V3 style) for independent expert scores
-        - Batched scatter-gather dispatch (each expert runs once per forward)
+        - N routed experts, dispatched via a three-phase schedule:
+            mode 0 (soft_all): every expert runs on every token, weighted
+              by softmax(router_logits / tau). Used for soft_warmup_steps
+              at the start of training so every expert gets gradient from
+              step 0 and no expert can "die" before learning.
+            mode 1 (blend): soft_out and hard top-k out are blended by a
+              scalar alpha ∈ [0, 1]. alpha anneals 0 → 1 across
+              blend_anneal_steps so the transition to hard routing is
+              smooth rather than a cliff where collapse can resume.
+            mode 2 (hard_topk): classic top-k sigmoid gating with
+              scatter-gather dispatch. Active from the end of blend
+              annealing onward.
+        - Loop-aware router: adds a learned per-loop embedding to x.
+        - Differentiable balance losses on the softmax distribution
+          (importance + logit bias) + router z-loss.
 
-    Load balancing via auxiliary loss + router z-loss to prevent expert collapse.
+    routing_mode is a Python int attribute — changing it triggers exactly
+    two torch.compile recompilations per run (at the soft→blend and
+    blend→hard transitions), which is cheap. routing_alpha is a scalar
+    tensor buffer so the training loop can update it in-place every step
+    without recompiling during the blend phase.
     """
 
     def __init__(self, config: NanoOSRTv4Config) -> None:
@@ -119,18 +136,89 @@ class MoELayer(nn.Module):
         self.num_routed = config.num_routed_experts
         self.top_k = config.top_k_experts
         self.num_loops = config.recursive_loops
-        self.z_loss_coeff = config.router_z_loss_coeff
+        self.temperature = config.router_softmax_temperature
+        self.capacity_capped = config.router_capacity_capped
+        self.candidate_k = min(config.router_candidate_k, self.num_routed)
+        self.capacity_factor = config.router_capacity_factor
 
-        # Router noise schedule. Stored as a scalar tensor buffer so
-        # torch.compile sees it as a graph input (no .item() graph break)
-        # and the training loop can update it in-place each step to
-        # implement the linear anneal from router_noise_std_init down to
-        # router_noise_std_final. Setting it to 0.0 temporarily lets the
-        # training loop run "clean" diagnostic forwards that measure
-        # learned routing without the noise perturbation.
+        # Routing phase. 0 = soft_all, 1 = blend, 2 = hard_topk. Default
+        # hard so eval / from-scratch inference acts like a normal MoE
+        # without anyone having to set it. The training loop flips it
+        # to 0 at step 0 and progresses through 1 → 2 on schedule.
+        self.routing_mode: int = 2
+
+        # Blend mixing coefficient. 0.0 = pure soft, 1.0 = pure hard.
+        # Only consulted in mode 1. Scalar tensor buffer so in-place
+        # updates don't recompile.
+        self.register_buffer(
+            "routing_alpha",
+            torch.tensor(1.0, dtype=torch.float32),
+            persistent=False,
+        )
+
+        # Router noise schedule (legacy, optional). Scalar tensor buffer.
+        # Defaults to 0.0 now that soft warmup handles tie-locking, but
+        # left in so it can be re-enabled from config if we ever want
+        # extra jitter during hard-phase training.
         self.register_buffer(
             "noise_std",
             torch.tensor(config.router_noise_std_init, dtype=torch.float32),
+            persistent=False,
+        )
+        # Gumbel-top-k temperature. Scalar tensor buffer so training loop
+        # updates in-place without recompiles. Used inside _hard_gate to
+        # add Gumbel(0, tau) noise to the selection logits, breaking
+        # deterministic winner lock-in. Weights are still computed from
+        # the clean sigmoid — only the *selection* is noised.
+        self.register_buffer(
+            "gumbel_tau",
+            torch.tensor(config.router_gumbel_tau_init, dtype=torch.float32),
+            persistent=False,
+        )
+
+        # ── Balance-bias controller ──
+        # Per-expert additive bias applied to selection_logits as part
+        # of the routing mechanism (both train and eval). Controls load
+        # imbalance by pushing over-used experts down and under-used
+        # experts up. Persistent so it survives checkpoint save/load —
+        # the trained bias is part of the model, not a training-only
+        # crutch.
+        #
+        # IMPORTANT: the controller runs at once-per-optimizer-step
+        # cadence, NOT per MoE call. The 6 recursive-loop calls within
+        # a forward pass are a sequence through evolving hidden states
+        # and are not independent samples — updating the bias after
+        # each call causes later calls to react to bias changes driven
+        # by earlier calls, producing oscillation. We accumulate clean
+        # biased assignment counts across the 6 loops in per-block
+        # buffers, then the training loop calls `apply_balance_update`
+        # after optimizer.step() to consume the accumulator and update
+        # the bias exactly once.
+        self.bias_enabled = config.router_balance_bias_enabled
+        self.bias_update_rate = config.router_balance_bias_update_rate
+        self.bias_ema_rate = config.router_balance_bias_ema_rate
+        self.bias_max = config.router_balance_bias_max
+        self.register_buffer(
+            "router_balance_bias",
+            torch.zeros(self.num_routed, dtype=torch.float32),
+            persistent=True,
+        )
+        # Per-step accumulator. Reset by apply_balance_update().
+        self.register_buffer(
+            "balance_count_accum",
+            torch.zeros(self.num_routed, dtype=torch.float32),
+            persistent=False,
+        )
+        self.register_buffer(
+            "balance_total_accum",
+            torch.zeros((), dtype=torch.float32),
+            persistent=False,
+        )
+        # Non-persistent EMA of recent assignment fractions — used for
+        # diagnostic logging only. Updated inside apply_balance_update.
+        self.register_buffer(
+            "expert_ema_fraction",
+            torch.full((self.num_routed,), 1.0 / self.num_routed, dtype=torch.float32),
             persistent=False,
         )
 
@@ -142,57 +230,74 @@ class MoELayer(nn.Module):
             [ExpertFFN(config.dim, config.expert_hidden) for _ in range(self.num_routed)]
         )
 
-        # Router: projects hidden state to expert scores.
-        # Loop-aware routing: add a learned per-loop embedding to the hidden
-        # state before the router projection. Addition (not concat) keeps
-        # router parameters at (dim -> num_routed) instead of (2*dim -> num_routed),
-        # halving router params with equivalent expressive power because a
-        # linear layer over cat([x, e]) can always be re-expressed as the
-        # sum of two linear layers over x and e.
+        # Router: projects hidden state to expert scores. Loop-aware: we
+        # add a learned per-loop embedding before the projection.
+        # Additive (not concat) keeps router params at dim → num_routed.
         #
-        # Loop embeddings get their own larger init_std
-        # (config.loop_embedding_init_std, default 0.1) so that they
-        # actually shift routing between loops at init — the default
-        # 0.02 was too small compared to the x-signal std ~0.78, making
-        # early routing loop-invariant.
-        #
-        # NOTE: HF PreTrainedModel.post_init() walks the module tree and
-        # calls _init_weights on every nn.Embedding with
-        # initializer_range (default 0.02), which would silently stomp
-        # whatever we set here. We tag this embedding with
-        # _osrt_init_std so the overridden _init_weights in
-        # NanoOSRTv4PreTrainedModel uses config.loop_embedding_init_std
-        # instead. Do NOT call nn.init.normal_ here — post_init will
-        # overwrite it anyway; the tag is what actually takes effect.
+        # Loop embeddings get a larger init std (config.loop_embedding_init_std)
+        # so routing actually differs across loops at init — default 0.02
+        # is too small vs the x-signal magnitude. The _osrt_init_std tag
+        # survives HF's post_init() which would otherwise stomp it.
         self.loop_embeddings = nn.Embedding(config.recursive_loops, config.dim)
         self.loop_embeddings._osrt_init_std = config.loop_embedding_init_std
         self.router = nn.Linear(config.dim, self.num_routed, bias=False)
+        # Tag so _init_weights row-normalises this linear layer: every
+        # expert row starts with equal norm, preventing any single row
+        # from winning globally at init (independent of x).
+        self.router._osrt_router_row_norm = True
 
         # Pre-register loop index tensors to avoid torch.tensor() in forward
         self.register_buffer(
             "loop_indices", torch.arange(config.recursive_loops), persistent=False
         )
 
-        # Store losses for training (load-balance and z-loss kept separate)
-        self.load_balance_loss: Tensor | None = None
+        # Per-layer losses, set during training forward, accumulated by
+        # the outer model. Kept separate so the wrapper can apply distinct
+        # coefficients without re-deriving ratios.
+        self.importance_loss: Tensor | None = None
+        self.logit_bias_loss: Tensor | None = None
         self.z_loss: Tensor | None = None
 
         # Per-loop telemetry — indexed [0..num_loops-1], overwritten on
-        # each forward. Used by the training loop for per-loop W&B metrics.
-        # Keep as plain tensors (no grad) so logging is free.
+        # each forward. Plain Python so logging is free.
         #
-        # router_prob_entropy: entropy of the normalised sigmoid probs. Can
-        # be near-uniform even when top-k is collapsed — not a reliable
-        # collapse detector by itself.
-        #
-        # assignment_entropy: entropy of the actual top-k token assignment
-        # distribution. Uniform routing gives ~ln(num_routed)=2.40, full
-        # top-2 collapse gives ~ln(2)=0.69. THIS is the reliable metric.
+        # last_router_entropy: entropy of the softmax distribution. Used
+        #   during soft warmup as a secondary metric.
+        # last_assignment_entropy: entropy of the NOISY top-k assignment
+        #   counts (training-time: what actually happens during
+        #   forward/backward). Uniform routing ~ ln(N); collapse ~ ln(k).
+        # last_clean_assignment_entropy: entropy of the CLEAN top-k
+        #   assignment counts (no Gumbel noise) — what deterministic
+        #   inference would produce. Divergence between noisy and clean
+        #   means training is propped up by sampling, not by learned
+        #   preferences. Clean is the real health metric.
+        # last_expert_fraction / last_clean_expert_fraction: per-expert
+        #   fractions corresponding to the two histograms above.
         self.last_router_entropy: list[float] = [0.0] * config.recursive_loops
+        # Noisy: training-time selection (bias + Gumbel noise)
         self.last_assignment_entropy: list[float] = [0.0] * config.recursive_loops
+        # Clean biased: inference-time selection (bias, no noise) —
+        # THIS is the decisive health metric because the bias is part
+        # of the routing mechanism.
+        self.last_clean_assignment_entropy: list[float] = [0.0] * config.recursive_loops
+        # Raw: router_logits alone, no bias, no noise. Diagnostic only —
+        # shows what the raw router has learned. May collapse even when
+        # the biased/clean view stays healthy; that's acceptable as long
+        # as the deployed model includes the bias.
+        self.last_raw_assignment_entropy: list[float] = [0.0] * config.recursive_loops
         self.last_expert_fraction: list[list[float]] = [
             [0.0] * config.num_routed_experts for _ in range(config.recursive_loops)
         ]
+        self.last_clean_expert_fraction: list[list[float]] = [
+            [0.0] * config.num_routed_experts for _ in range(config.recursive_loops)
+        ]
+        self.last_raw_expert_fraction: list[list[float]] = [
+            [0.0] * config.num_routed_experts for _ in range(config.recursive_loops)
+        ]
+        # Capacity-capped telemetry
+        self.last_overflow_rate: list[float] = [0.0] * config.recursive_loops
+        self.last_assigned_per_token: list[float] = [float(self.top_k)] * config.recursive_loops
+        self.last_candidate_rank_mean: list[float] = [0.0] * config.recursive_loops
 
     def forward(self, x: Tensor, loop_idx: int) -> Tensor:
         """Forward pass through MoE.
@@ -207,55 +312,474 @@ class MoELayer(nn.Module):
         B, S, D = x.shape
 
         # Reset losses at start of every forward (prevents stale values in eval)
-        self.load_balance_loss = None
+        self.importance_loss = None
+        self.logit_bias_loss = None
         self.z_loss = None
 
         # Shared expert (unconditional)
         shared_out = self.shared_expert(x)
 
         # Loop-aware routing: add the learned per-loop embedding to x.
-        # Broadcasts (dim,) -> (B, S, dim) without materialising an
-        # expanded tensor, then router projects (dim -> num_routed).
         loop_emb = self.loop_embeddings(self.loop_indices[loop_idx])  # (dim,)
         router_input = x + loop_emb  # (B, S, dim)
         router_logits = self.router(router_input)  # (B, S, num_routed)
 
-        # Training-time router noise (Switch-Transformer style). Breaks
-        # deterministic top-k tie-locking at init when all sigmoid values
-        # are near 0.5 and the same two indices would win every time.
-        # noise_std is a scalar tensor buffer — zero means clean routing,
-        # so no Python-level branching is required and torch.compile
-        # stays happy. Training loop sets it to 0.0 temporarily during
-        # diagnostic forwards to measure learned (non-random) routing.
-        if self.training:
+        # Legacy router noise (optional — defaults to 0). Left for hard
+        # phase jitter only; applying it during soft dispatch would
+        # perturb the balance loss targets without any routing benefit.
+        if self.training and self.routing_mode == 2:
             router_logits = router_logits + torch.randn_like(router_logits) * self.noise_std
 
-        # Sigmoid gating: each expert gate is independent (DeepSeek-V3 style)
-        router_probs = torch.sigmoid(router_logits)
+        # Differentiable balance losses always use the softmax distribution,
+        # regardless of routing mode. We compute soft_probs here so it's
+        # available to both the soft dispatch path and the loss path.
+        soft_probs = F.softmax(router_logits / self.temperature, dim=-1)
 
-        # Top-k selection
-        top_k_weights, top_k_indices = torch.topk(router_probs, self.top_k, dim=-1)
-
-        # Renormalise the selected weights so their sum is 1.0 per token.
-        # Without this, if all sigmoid values are small (e.g. early training
-        # with low-magnitude logits) the routed MoE output magnitude is
-        # also small and gradients into the router are suppressed. With
-        # renormalisation, the routed output has a consistent scale
-        # regardless of the absolute sigmoid magnitudes.
-        top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True).clamp_min(1e-6)
-
-        # Compute load balancing + z-loss (kept separate for independent scaling)
         if self.training:
-            self._compute_losses(router_logits, router_probs, top_k_indices, B, S)
-            self._record_telemetry(router_probs, top_k_indices, loop_idx)
+            self._compute_losses(router_logits, soft_probs)
 
-        # Batched scatter-gather dispatch: each expert runs exactly once
-        routed_out = self._dispatch_experts(
-            x.reshape(-1, D), top_k_indices.reshape(-1, self.top_k),
-            top_k_weights.reshape(-1, self.top_k), D,
+        mode = self.routing_mode
+        if mode == 0:
+            # Pure soft dispatch. Shadow telemetry shows what the
+            # deployed path (capped or uncapped hard) would produce.
+            routed_out = self._soft_dispatch(x, soft_probs)
+            if self.training:
+                with torch.no_grad():
+                    if self.capacity_capped:
+                        # Shadow capped dispatch for telemetry only
+                        sig = torch.sigmoid(router_logits)
+                        N = B * S
+                        cap = math.ceil(
+                            self.capacity_factor * N * self.top_k / self.num_routed
+                        )
+                        cand_s, cand_i = torch.topk(
+                            sig.reshape(N, self.num_routed),
+                            self.candidate_k, dim=-1,
+                        )
+                        shadow_assigned, shadow_raw = self._shadow_capped(
+                            cand_i, N, cap, sig, B, S, loop_idx,
+                        )
+                        self._record_hard_telemetry(
+                            soft_probs, shadow_assigned, shadow_assigned,
+                            shadow_raw, loop_idx,
+                        )
+                    else:
+                        noisy_idx, clean_biased_idx, clean_raw_idx = (
+                            self._shadow_selections(router_logits)
+                        )
+                        self._record_hard_telemetry(
+                            soft_probs, noisy_idx, clean_biased_idx,
+                            clean_raw_idx, loop_idx,
+                        )
+                if self.bias_enabled:
+                    self._accumulate_balance_counts(
+                        shadow_assigned if self.capacity_capped
+                        else clean_biased_idx
+                    )
+        elif mode == 2:
+            # Pure hard dispatch
+            if self.capacity_capped:
+                routed_out = self._capped_dispatch(x, router_logits, loop_idx)
+            else:
+                top_k_weights, top_k_indices = self._hard_gate(router_logits)
+                routed_flat = self._dispatch_experts(
+                    x.reshape(-1, D),
+                    top_k_indices.reshape(-1, self.top_k),
+                    top_k_weights.reshape(-1, self.top_k),
+                    D,
+                )
+                routed_out = routed_flat.view(B, S, D)
+                if self.training:
+                    with torch.no_grad():
+                        raw_idx = torch.topk(
+                            router_logits, self.top_k, dim=-1
+                        ).indices
+                    self._record_hard_telemetry(
+                        soft_probs, top_k_indices, top_k_indices,
+                        raw_idx, loop_idx,
+                    )
+        else:
+            # Blend — soft + hard, mixed by alpha.
+            soft_out = self._soft_dispatch(x, soft_probs)
+            if self.capacity_capped:
+                hard_out = self._capped_dispatch(x, router_logits, loop_idx)
+            else:
+                top_k_weights, top_k_indices = self._hard_gate(router_logits)
+                hard_flat = self._dispatch_experts(
+                    x.reshape(-1, D),
+                    top_k_indices.reshape(-1, self.top_k),
+                    top_k_weights.reshape(-1, self.top_k),
+                    D,
+                )
+                hard_out = hard_flat.view(B, S, D)
+            alpha = self.routing_alpha
+            routed_out = alpha * hard_out + (1.0 - alpha) * soft_out
+
+        return shared_out + routed_out
+
+    def _shadow_capped(
+        self,
+        cand_indices: Tensor,
+        N: int,
+        capacity: int,
+        sig: Tensor,
+        B: int,
+        S: int,
+        loop_idx: int,
+    ) -> tuple[Tensor, Tensor]:
+        """Shadow capacity-capped assignment for telemetry during soft.
+
+        Also records overflow/assigned/rank telemetry into the per-loop
+        fields so the training loop can log them during soft phase
+        (where the main capped dispatch doesn't run).
+
+        Returns (capped_indices, raw_indices) both (B, S, top_k).
+        """
+        assigned, _, slots_filled, rank_sum = self._assign_with_caps(
+            cand_indices, None, N, capacity, sig.device,
         )
 
-        return shared_out + routed_out.view(B, S, D)
+        # Record capacity telemetry from the shadow computation
+        if 0 <= loop_idx < len(self.last_overflow_rate):
+            self.last_overflow_rate[loop_idx] = (
+                (slots_filled < self.top_k).float().mean().item()
+            )
+            self.last_assigned_per_token[loop_idx] = (
+                slots_filled.float().mean().item()
+            )
+            filled = slots_filled.clamp_min(1).float()
+            self.last_candidate_rank_mean[loop_idx] = (
+                (rank_sum / filled).mean().item()
+            )
+
+        raw_idx = torch.topk(
+            sig.reshape(N, self.num_routed), self.top_k, dim=-1,
+        ).indices.view(B, S, self.top_k)
+        return assigned.view(B, S, self.top_k), raw_idx
+
+    def _assign_with_caps(
+        self,
+        cand_indices: Tensor,
+        cand_scores: Tensor | None,
+        N: int,
+        capacity: int,
+        device: torch.device,
+    ) -> tuple[Tensor, Tensor]:
+        """Race-free capacity-capped assignment.
+
+        Iterates over (candidate_rank, expert_id) and for each expert
+        assigns at most `remaining_capacity` tokens. This avoids the
+        vectorised race where multiple tokens pass the capacity check
+        simultaneously and all get assigned, blowing past the cap.
+
+        O(candidate_k × num_routed) = 66 iterations for default config.
+
+        Returns (assigned_indices, assigned_weights, slots_filled, rank_sum)
+        where assigned is (N, top_k), weights is (N, top_k),
+        slots_filled is (N,) counting how many experts each token got,
+        and rank_sum is (N,) total candidate rank across assigned slots
+        (used to compute candidate_rank_mean = rank_sum / slots_filled).
+        Unfilled slots have index -1 and weight 0. Callers must clamp
+        index to 0 before passing to dispatch (so the unfilled slot
+        routes through expert 0 with zero weight — harmless). Telemetry
+        must filter out -1 entries to avoid inflating expert 0 counts.
+        """
+        assigned = torch.full((N, self.top_k), -1, dtype=torch.long, device=device)
+        assigned_w = torch.zeros(N, self.top_k, device=device)
+        expert_load = torch.zeros(self.num_routed, dtype=torch.long, device=device)
+        slots_filled = torch.zeros(N, dtype=torch.long, device=device)
+        rank_sum = torch.zeros(N, dtype=torch.float32, device=device)
+
+        for rank in range(self.candidate_k):
+            if (slots_filled >= self.top_k).all():
+                break
+
+            eid_col = cand_indices[:, rank]                       # (N,)
+            eligible = slots_filled < self.top_k                  # (N,) bool
+
+            eligible_idx = eligible.nonzero(as_tuple=True)[0]     # (M,)
+            if eligible_idx.numel() == 0:
+                break
+            eligible_eid = eid_col[eligible_idx]                  # (M,)
+
+            # Sort eligible tokens by expert ID for grouping
+            sorted_order = eligible_eid.argsort(stable=True)      # (M,)
+            sorted_eid = eligible_eid[sorted_order]               # (M,)
+            M = sorted_eid.shape[0]
+
+            # Compute within-group position via segment-cumsum trick:
+            # group_change[i]=1 at group boundaries, 0 otherwise
+            group_change = torch.ones(M, dtype=torch.long, device=device)
+            if M > 1:
+                group_change[1:] = (sorted_eid[1:] != sorted_eid[:-1]).long()
+            # group_id per position (0-based)
+            group_id = torch.cumsum(group_change, dim=0) - 1      # (M,)
+            # Index of the first element of each group
+            group_start_positions = group_change.nonzero(as_tuple=True)[0]  # (G,)
+            # Map each position to its group's start index
+            start_of_group = group_start_positions[group_id]      # (M,)
+            # Within-group position = position - start of group
+            arange_M = torch.arange(M, device=device)
+            within_group_pos = arange_M - start_of_group          # (M,)
+
+            # Remaining capacity per expert, indexed per sorted token
+            remaining = (capacity - expert_load).clamp(min=0)     # (num_routed,)
+            remaining_per_token = remaining[sorted_eid]           # (M,)
+
+            # Token fits if its within-group position < remaining capacity
+            fits = within_group_pos < remaining_per_token         # (M,) bool
+
+            # Map back from sorted order to eligible-token order
+            fits_orig = torch.zeros(M, dtype=torch.bool, device=device)
+            fits_orig[sorted_order] = fits
+            # Indices into the full N-sized arrays for tokens that get assigned
+            take = eligible_idx[fits_orig]                        # (T,)
+
+            if take.numel() == 0:
+                continue
+
+            take_eid = eid_col[take]                              # (T,)
+            sidx = slots_filled[take]
+            assigned[take, sidx] = take_eid
+            if cand_scores is not None:
+                assigned_w[take, sidx] = cand_scores[take, rank].float()
+            slots_filled[take] += 1
+            rank_sum[take] += rank
+
+            # Update expert load counts
+            assigned_counts = torch.zeros(
+                self.num_routed, dtype=torch.long, device=device,
+            )
+            assigned_counts.scatter_add_(
+                0, take_eid, torch.ones_like(take_eid),
+            )
+            expert_load += assigned_counts
+
+        return assigned, assigned_w, slots_filled, rank_sum
+
+    def _shadow_selections(
+        self, router_logits: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Compute three top-k index sets for telemetry + bias update.
+
+        Returns (noisy_biased, clean_biased, clean_raw):
+          - noisy_biased: router_logits + bias + Gumbel(τ)
+              What the training-time hard path would select right now.
+              Used as the source for the bias controller's update.
+          - clean_biased: router_logits + bias, no noise
+              What deterministic inference produces. The DECISIVE
+              health metric — if this is balanced the deployed model
+              is fine.
+          - clean_raw: router_logits alone, no bias, no noise
+              Diagnostic only. Shows what the raw router has learned.
+              May look collapsed even when clean_biased is healthy;
+              that's acceptable since the bias is part of the model.
+        """
+        if self.bias_enabled:
+            biased = router_logits + self.router_balance_bias.view(1, 1, -1)
+        else:
+            biased = router_logits
+
+        clean_biased_idx = torch.topk(biased, self.top_k, dim=-1).indices
+        clean_raw_idx = torch.topk(router_logits, self.top_k, dim=-1).indices
+
+        if self.gumbel_tau > 0:
+            u = torch.rand_like(router_logits).clamp_min(1e-9)
+            gumbel = -torch.log(-torch.log(u))
+            noisy_logits = biased + self.gumbel_tau * gumbel
+            noisy_biased_idx = torch.topk(noisy_logits, self.top_k, dim=-1).indices
+        else:
+            noisy_biased_idx = clean_biased_idx
+
+        return noisy_biased_idx, clean_biased_idx, clean_raw_idx
+
+    @torch._dynamo.disable
+    @torch.no_grad()
+    def _accumulate_balance_counts(self, top_k_indices: Tensor) -> None:
+        """Accumulate per-expert assignment counts for the balance
+        controller. Called from forward() once per MoE invocation
+        during training; reset by `apply_balance_update()` once per
+        optimizer step.
+        """
+        if not self.bias_enabled:
+            return
+        flat = top_k_indices.reshape(-1)
+        counts = torch.bincount(flat, minlength=self.num_routed).float()
+        self.balance_count_accum.add_(counts)
+        self.balance_total_accum.add_(counts.sum())
+
+    @torch.no_grad()
+    def apply_balance_update(self) -> None:
+        """Consume the accumulator and update the balance bias once.
+
+        Called from the training loop after optimizer.step(), not from
+        forward. This gives the controller integrated feedback over all
+        6 recursive-loop calls of this block's MoELayer in the step
+        (plus any gradient-accumulation micro-batches), so it sees the
+        full step's routing distribution as one signal instead of
+        reacting to intra-step bias drift from earlier loops.
+
+        Resets the accumulator afterwards. If the accumulator is empty
+        (e.g. an eval-only step, or apply called twice), this is a
+        no-op — we must NOT update bias from an all-zero histogram,
+        which would push every expert toward +1/N uniformly.
+        """
+        if not self.bias_enabled:
+            return
+        if self.balance_total_accum.item() == 0.0:
+            return
+        total = self.balance_total_accum
+        current_frac = self.balance_count_accum / total
+
+        # EMA for smoothed telemetry (not used by the controller)
+        self.expert_ema_fraction.lerp_(current_frac, self.bias_ema_rate)
+
+        target = 1.0 / self.num_routed
+        delta = current_frac - target
+        self.router_balance_bias.add_(delta, alpha=-self.bias_update_rate)
+        self.router_balance_bias.clamp_(-self.bias_max, self.bias_max)
+
+        # Reset for next step
+        self.balance_count_accum.zero_()
+        self.balance_total_accum.zero_()
+
+    def _hard_gate(self, router_logits: Tensor) -> tuple[Tensor, Tensor]:
+        """Selection-logit gating + top-k + weight renormalization.
+
+        Three sources are combined to form the selection logits:
+          1. router_logits (what the router learned)
+          2. router_balance_bias (per-expert additive — part of the
+             routing mechanism, applied in both training and eval so
+             the deployed path matches the training path)
+          3. Gumbel(0, tau) noise during training only
+
+        The *weights* returned come from the CLEAN sigmoid of
+        router_logits alone (no bias, no noise), so gradient flows to
+        the router through a meaningful path for the experts that
+        actually were selected.
+
+        Returns (top_k_weights, top_k_indices) both shaped (B, S, top_k).
+        """
+        # Bias is part of the routing mechanism — applied always
+        if self.bias_enabled:
+            selection_base = router_logits + self.router_balance_bias.view(1, 1, -1)
+        else:
+            selection_base = router_logits
+
+        # Gumbel noise during training only
+        if self.training and self.gumbel_tau > 0:
+            u = torch.rand_like(router_logits).clamp_min(1e-9)
+            gumbel = -torch.log(-torch.log(u))
+            selection_logits = selection_base + self.gumbel_tau * gumbel
+        else:
+            selection_logits = selection_base
+
+        _, top_k_indices = torch.topk(selection_logits, self.top_k, dim=-1)
+
+        # Gather CLEAN sigmoid weights for the selected experts
+        clean_sig = torch.sigmoid(router_logits)
+        top_k_weights = clean_sig.gather(-1, top_k_indices)
+        top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True).clamp_min(1e-6)
+        return top_k_weights, top_k_indices
+
+    @torch._dynamo.disable
+    def _soft_dispatch(self, x: Tensor, soft_probs: Tensor) -> Tensor:
+        """Soft all-expert dispatch: every expert runs on every token.
+
+        This is ~num_routed× more FLOPs than top-k routing but guarantees
+        that every expert receives gradient at every step — no dead
+        experts, no self-reinforcing winners. Only used during the
+        soft_warmup / blend phases (total ~1000 steps by default).
+
+        Accumulates one expert at a time to avoid materialising the
+        (B, S, num_routed, D) stacked tensor, which would be ~140MB at
+        seq_len=2048, dim=1536, fp16.
+        """
+        out = torch.zeros_like(x)
+        for eid in range(self.num_routed):
+            w = soft_probs[..., eid].unsqueeze(-1)  # (B, S, 1)
+            out = out + w * self.experts[eid](x)
+        return out
+
+    @torch._dynamo.disable
+    def _capped_dispatch(
+        self, x: Tensor, router_logits: Tensor, loop_idx: int,
+    ) -> Tensor:
+        """Capacity-capped expert dispatch.
+
+        For each token, scans candidates in descending sigmoid score
+        and assigns the first top_k experts that still have capacity.
+        This structurally guarantees bounded max by construction —
+        no expert can hoard more than `capacity` tokens regardless of
+        what the router prefers.
+
+        Same path in train and eval. No Gumbel, no bias — the cap IS
+        the balance mechanism.
+
+        Gradient flows through the sigmoid weights of the chosen
+        experts exactly like uncapped top-k; only the selection is
+        changed by the capacity constraint.
+
+        Returns the routed output tensor (B, S, D).
+        """
+        B, S, D = x.shape
+        N = B * S
+
+        sig = torch.sigmoid(router_logits)
+        cand_scores, cand_indices = torch.topk(
+            sig.reshape(N, self.num_routed), self.candidate_k, dim=-1,
+        )
+        flat_x = x.reshape(N, D)
+
+        capacity = math.ceil(
+            self.capacity_factor * N * self.top_k / self.num_routed
+        )
+
+        assigned, assigned_w, slots_filled, rank_sum = self._assign_with_caps(
+            cand_indices, cand_scores, N, capacity, x.device,
+        )
+
+        # Renormalize weights over actually-assigned experts (unfilled
+        # slots keep weight 0). Clamp indices to 0 for dispatch only —
+        # unfilled slots route through expert 0 with zero weight
+        # (harmless, bounded by overflow rate).
+        weight_sum = assigned_w.sum(dim=-1, keepdim=True).clamp_min(1e-6)
+        assigned_w = assigned_w / weight_sum
+
+        dispatch_idx = assigned.clamp(min=0)
+        routed_out = self._dispatch_experts(
+            flat_x, dispatch_idx, assigned_w, D,
+        )
+
+        # Record capacity telemetry
+        if 0 <= loop_idx < len(self.last_overflow_rate):
+            self.last_overflow_rate[loop_idx] = (
+                (slots_filled < self.top_k).float().mean().item()
+            )
+            self.last_assigned_per_token[loop_idx] = (
+                slots_filled.float().mean().item()
+            )
+            filled = slots_filled.clamp_min(1).float()
+            self.last_candidate_rank_mean[loop_idx] = (
+                (rank_sum / filled).mean().item()
+            )
+
+        # Record routing histogram telemetry (reuse existing method).
+        # Capped assignment is both the training and inference path, so
+        # we pass it as both "noisy" and "clean_biased". Raw uncapped
+        # top-k stays as diagnostic.
+        if self.training:
+            with torch.no_grad():
+                raw_idx = torch.topk(
+                    sig.reshape(N, self.num_routed), self.top_k, dim=-1,
+                ).indices.view(B, S, self.top_k)
+            soft_probs = F.softmax(router_logits / self.temperature, dim=-1)
+            capped_idx = assigned.view(B, S, self.top_k)
+            self._record_hard_telemetry(
+                soft_probs, capped_idx, capped_idx, raw_idx, loop_idx,
+            )
+
+        return routed_out.view(B, S, D)
 
     @torch._dynamo.disable
     def _dispatch_experts(
@@ -307,78 +831,123 @@ class MoELayer(nn.Module):
         result = result.view(N, self.top_k, D).sum(dim=1)
         return result
 
-    def _compute_losses(
-        self, router_logits: Tensor, router_probs: Tensor,
-        top_k_indices: Tensor, B: int, S: int,
-    ) -> None:
-        """Compute load balancing loss and router z-loss (stored separately).
+    def _compute_losses(self, router_logits: Tensor, soft_probs: Tensor) -> None:
+        """Differentiable routing losses.
 
-        Load balancing (Switch Transformer style): encourages uniform routing.
-        Z-loss (ST-MoE / PaLM): penalises large router logits for stability.
+        All three losses are computed from the softmax router distribution
+        and the raw logits — they have meaningful gradient regardless of
+        routing_mode, so they work during soft warmup, blend, and hard
+        phases alike.
 
-        Losses are stored on separate attributes so the training loss can
-        apply router_aux_loss_coeff and router_z_loss_coeff independently.
+        - importance_loss: ``N * sum(importance**2)`` where importance is
+          the per-expert mean softmax probability. Minimum 1.0 when
+          experts are loaded uniformly; grows quadratically with
+          concentration. Unlike the Switch-Transformer load balance loss
+          (which multiplies mean-prob by hard-assignment fractions), this
+          does NOT saturate when an expert dies — dead experts still get
+          gradient pushing their importance back up.
+
+        - logit_bias_loss: mean squared deviation of each expert's mean
+          logit from the grand mean. Attacks the global expert ordering
+          that hard top-k exploits to pick consistent winners regardless
+          of token content.
+
+        - z_loss: mean squared logit, preventing the router from pushing
+          logits to extreme magnitudes.
         """
-        # Fraction of tokens routed to each expert — bincount avoids the
-        # (B, S, top_k, num_routed) one-hot allocation which spikes memory
-        # at seq_len 4096/8192. Cast is needed because bincount returns int.
-        flat_indices = top_k_indices.reshape(-1)  # (B * S * top_k,)
-        tokens_per_expert = torch.bincount(
-            flat_indices, minlength=self.num_routed
-        ).to(router_probs.dtype)
-        fraction_routed = tokens_per_expert / (B * S * self.top_k)
+        # Importance balance (differentiable surrogate for load balance)
+        importance = soft_probs.mean(dim=(0, 1))  # (num_routed,)
+        self.importance_loss = self.num_routed * (importance * importance).sum()
 
-        # Average router probability per expert (sigmoid — matches gating)
-        avg_prob = router_probs.mean(dim=(0, 1))  # (num_routed,)
+        # Logit centering: penalise per-expert mean logit deviation
+        mean_logits = router_logits.mean(dim=(0, 1))  # (num_routed,)
+        centered = mean_logits - mean_logits.mean()
+        self.logit_bias_loss = centered.pow(2).mean()
 
-        # Load balancing loss (Switch Transformer style)
-        self.load_balance_loss = self.num_routed * (fraction_routed * avg_prob).sum()
-
-        # Router z-loss: penalise large logits to prevent overconfident routing
-        # For sigmoid routing, penalise squared logits directly (large |logit|
-        # pushes sigmoid toward 0 or 1, reducing routing flexibility).
+        # Z-loss: squared logit magnitudes
         self.z_loss = router_logits.pow(2).mean()
 
+    @torch._dynamo.disable
     @torch.no_grad()
-    def _record_telemetry(
-        self, router_probs: Tensor, top_k_indices: Tensor, loop_idx: int,
-    ) -> None:
-        """Record per-loop routing telemetry.
+    def _record_soft_telemetry(self, soft_probs: Tensor, loop_idx: int) -> None:
+        """Telemetry for the soft-routing phase.
 
-        Called inside forward() during training only. Values live on CPU
-        as plain Python lists so the training loop can log them cheaply.
-
-        Two entropy metrics:
-          - router_prob_entropy: entropy of the normalised sigmoid probs.
-            CAN BE MISLEADING — near-uniform sigmoid can still produce
-            deterministic top-k (the failure mode we saw at step 200 of
-            the first sanity run).
-          - assignment_entropy: entropy of the actual top-k token
-            assignment distribution. Uniform routing over 11 experts
-            gives ~ln(11) = 2.40; full top-2 collapse gives ~ln(2) = 0.69.
-            THIS is the reliable collapse detector.
+        No hard assignments exist yet, so last_assignment_entropy is set
+        equal to the softmax entropy (best proxy we have) and
+        last_expert_fraction holds the per-expert importance vector
+        (softmax mean over tokens) so the logger always has something
+        sensible to print.
         """
-        # 1. Router-prob entropy (kept for backwards compat + sanity)
-        norm = router_probs / (router_probs.sum(dim=-1, keepdim=True) + 1e-8)
-        prob_entropy = -(norm * (norm + 1e-8).log()).sum(dim=-1).mean()
+        prob_entropy = -(soft_probs * (soft_probs + 1e-8).log()).sum(dim=-1).mean()
         if 0 <= loop_idx < len(self.last_router_entropy):
             self.last_router_entropy[loop_idx] = prob_entropy.item()
 
-        # 2. Assignment entropy + per-expert fractions
-        flat = top_k_indices.reshape(-1)
-        counts = torch.bincount(flat, minlength=self.num_routed).float()
-        total = counts.sum().clamp_min(1)
-        fractions_tensor = counts / total
-        fractions = fractions_tensor.tolist()
+        importance = soft_probs.mean(dim=(0, 1))  # (num_routed,)
+        fractions = importance.tolist()
         if 0 <= loop_idx < len(self.last_expert_fraction):
             self.last_expert_fraction[loop_idx] = fractions
 
-        # Entropy over the actual assignment distribution (the real metric)
-        assign_entropy = -(
-            fractions_tensor * (fractions_tensor + 1e-8).log()
-        ).sum()
+        # Entropy of the importance distribution — during healthy soft
+        # routing this should also be near ln(num_routed).
+        imp_entropy = -(importance * (importance + 1e-8).log()).sum()
         if 0 <= loop_idx < len(self.last_assignment_entropy):
-            self.last_assignment_entropy[loop_idx] = assign_entropy.item()
+            self.last_assignment_entropy[loop_idx] = imp_entropy.item()
+
+    @torch._dynamo.disable
+    @torch.no_grad()
+    def _record_hard_telemetry(
+        self,
+        soft_probs: Tensor,
+        top_k_indices: Tensor,
+        clean_biased_indices: Tensor | None,
+        clean_raw_indices: Tensor | None,
+        loop_idx: int,
+    ) -> None:
+        """Record three histograms per loop:
+          - noisy (actually used during training) → last_assignment_*
+          - clean biased (inference path) → last_clean_assignment_*
+          - clean raw (no bias, no noise, diagnostic) → last_raw_*
+
+        The decisive health metric is the clean biased view because
+        the bias is part of the routing mechanism.
+        """
+        def _hist(indices: Tensor) -> tuple[list[float], float]:
+            flat = indices.reshape(-1)
+            # Filter out -1 entries (unfilled capacity-capped slots)
+            # to avoid inflating expert 0 counts.
+            valid = flat[flat >= 0]
+            if valid.numel() == 0:
+                return [0.0] * self.num_routed, 0.0
+            counts = torch.bincount(valid, minlength=self.num_routed).float()
+            total = counts.sum().clamp_min(1)
+            fractions_tensor = counts / total
+            fractions = fractions_tensor.tolist()
+            entropy = -(fractions_tensor * (fractions_tensor + 1e-8).log()).sum().item()
+            return fractions, entropy
+
+        prob_entropy = -(soft_probs * (soft_probs + 1e-8).log()).sum(dim=-1).mean()
+        if 0 <= loop_idx < len(self.last_router_entropy):
+            self.last_router_entropy[loop_idx] = prob_entropy.item()
+
+        # Noisy (training) histogram
+        fractions, entropy = _hist(top_k_indices)
+        if 0 <= loop_idx < len(self.last_expert_fraction):
+            self.last_expert_fraction[loop_idx] = fractions
+            self.last_assignment_entropy[loop_idx] = entropy
+
+        # Clean biased (inference path) histogram
+        cb_src = clean_biased_indices if clean_biased_indices is not None else top_k_indices
+        fractions, entropy = _hist(cb_src)
+        if 0 <= loop_idx < len(self.last_clean_expert_fraction):
+            self.last_clean_expert_fraction[loop_idx] = fractions
+            self.last_clean_assignment_entropy[loop_idx] = entropy
+
+        # Raw (diagnostic) histogram
+        cr_src = clean_raw_indices if clean_raw_indices is not None else cb_src
+        fractions, entropy = _hist(cr_src)
+        if 0 <= loop_idx < len(self.last_raw_expert_fraction):
+            self.last_raw_expert_fraction[loop_idx] = fractions
+            self.last_raw_assignment_entropy[loop_idx] = entropy
 
 
 # ── Dense FFN ───────────────────────────────────────────────────────────
@@ -532,6 +1101,18 @@ class NanoOSRTv4PreTrainedModel(PreTrainedModel):
             nn.init.normal_(module.weight, mean=0.0, std=std)
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
+            # Router row-norm: if this linear layer is tagged as a router,
+            # rescale its rows to have equal norm so no expert starts
+            # with a larger weight row than any other. Without this, the
+            # expert whose row norm is luckiest at init gets selected
+            # disproportionately and hard top-k locks that advantage in
+            # before the router has learned anything about tokens.
+            if getattr(module, "_osrt_router_row_norm", False):
+                with torch.no_grad():
+                    w = module.weight.data
+                    row_norms = w.norm(dim=1, keepdim=True).clamp_min(1e-8)
+                    mean_norm = row_norms.mean()
+                    module.weight.data = (w / row_norms) * mean_norm
         elif isinstance(module, nn.Embedding):
             # HF's post_init() walks the tree and calls _init_weights on
             # every nn.Embedding with initializer_range (default 0.02).
@@ -594,7 +1175,12 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
         # Gradient checkpointing (disabled by default, enable for long sequences)
         self.gradient_checkpointing = False
 
-        self.post_init()
+        # Note: _no_ post_init() here. The outer NanoOSRTv4ForCausalLM
+        # wrapper calls post_init() exactly once on the full tree, which
+        # also initialises this inner model. Calling it in both places
+        # would re-init every parameter twice — not incorrect (the final
+        # values are still the tagged-custom ones), just wasteful and
+        # confusing when debugging init.
 
     def forward(
         self,
@@ -602,7 +1188,7 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
         past_key_values: list[tuple[Tensor, Tensor]] | None = None,
         use_cache: bool = False,
         **kwargs,
-    ) -> tuple[Tensor, list[Tensor], Tensor, Tensor, list[tuple[Tensor, Tensor]] | None]:
+    ) -> tuple[Tensor, list[Tensor], Tensor, Tensor, Tensor, list[tuple[Tensor, Tensor]] | None]:
         """Forward pass.
 
         Args:
@@ -613,8 +1199,10 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
             use_cache: Whether to return updated KV cache for generation.
 
         Returns:
-            (hidden_states, loop_rms_list, total_load_balance_loss,
-             total_z_loss, present_key_values)
+            (hidden_states, loop_rms_list, importance_loss, logit_bias_loss,
+             z_loss, present_key_values)
+            where the three MoE losses are summed across every MoE
+            application (num_blocks × recursive_loops).
         """
         x = self.embedding(input_ids)
         S = input_ids.shape[1]
@@ -638,14 +1226,29 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
                         f"(key, value) tuple, but entry {idx} has type "
                         f"{type(layer_past).__name__}."
                     )
-            if past_key_values[0] is not None:
-                key, value = past_key_values[0]
+            # Derive past_length from the first non-None layer and
+            # verify every other layer's cache length matches. A
+            # partially stale or malformed cache would produce
+            # inconsistent RoPE positions across effective layers.
+            past_length = 0
+            for idx, layer_past in enumerate(past_key_values):
+                if layer_past is None:
+                    continue
+                key, value = layer_past
                 if not isinstance(key, torch.Tensor) or not isinstance(value, torch.Tensor):
                     raise ValueError(
-                        "Invalid past_key_values: each non-None entry must contain "
-                        "torch.Tensor key/value tensors."
+                        f"past_key_values[{idx}] must contain Tensor "
+                        f"key/value pairs, got {type(key).__name__}/{type(value).__name__}."
                     )
-                past_length = key.shape[2]
+                layer_len = key.shape[2]
+                if past_length == 0:
+                    past_length = layer_len
+                elif layer_len != past_length:
+                    raise ValueError(
+                        f"past_key_values cache length mismatch: layer 0 "
+                        f"has {past_length} cached positions but layer "
+                        f"{idx} has {layer_len}."
+                    )
 
         required_seq_len = past_length + S
         if required_seq_len <= self.rope_cos.shape[1]:
@@ -657,6 +1260,7 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
                 self.rope_cos.shape[-1],
                 theta=getattr(self.config, "rope_theta", 10000.0),
                 device=x.device,
+                scaling=getattr(self.config, "rope_scaling", None),
             )
             cos = rope_cos[:, past_length:required_seq_len, :, :].to(
                 device=self.rope_cos.device, dtype=self.rope_cos.dtype
@@ -666,7 +1270,8 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
             )
 
         loop_rms: list[Tensor] = []
-        total_lb_loss = torch.tensor(0.0, device=x.device)
+        total_imp_loss = torch.tensor(0.0, device=x.device)
+        total_bias_loss = torch.tensor(0.0, device=x.device)
         total_z_loss = torch.tensor(0.0, device=x.device)
 
         use_ckpt = self.gradient_checkpointing and self.training
@@ -711,8 +1316,10 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
                         presents.append(present_kv)
 
                 # Accumulate MoE losses (kept separate for independent scaling)
-                if block.moe.load_balance_loss is not None:
-                    total_lb_loss = total_lb_loss + block.moe.load_balance_loss
+                if block.moe.importance_loss is not None:
+                    total_imp_loss = total_imp_loss + block.moe.importance_loss
+                if block.moe.logit_bias_loss is not None:
+                    total_bias_loss = total_bias_loss + block.moe.logit_bias_loss
                 if block.moe.z_loss is not None:
                     total_z_loss = total_z_loss + block.moe.z_loss
 
@@ -721,7 +1328,7 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
                 x = self.norm_loop(x)
 
         x = self.norm_out(x)
-        return x, loop_rms, total_lb_loss, total_z_loss, presents
+        return x, loop_rms, total_imp_loss, total_bias_loss, total_z_loss, presents
 
 
 class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
@@ -750,7 +1357,7 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
         use_cache: bool = False,
         **kwargs,
     ) -> CausalLMOutputWithPast:
-        hidden, loop_rms, lb_loss, z_loss, presents = self.model(
+        hidden, loop_rms, imp_loss, bias_loss, z_loss, presents = self.model(
             input_ids,
             past_key_values=past_key_values,
             use_cache=use_cache,
@@ -770,14 +1377,16 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
             )
             # MoE losses are accumulated across all (num_blocks × recursive_loops)
             # effective MoE applications (18 for default v4). Normalise by that
-            # count so the configured coefficient matches the per-layer weight
-            # instead of being silently multiplied by 18.
+            # count so the configured coefficients match the per-layer
+            # weights instead of being silently multiplied by 18.
             n_moe_layers = self.config.num_blocks * self.config.recursive_loops
-            lb_norm = lb_loss / n_moe_layers
+            imp_norm = imp_loss / n_moe_layers
+            bias_norm = bias_loss / n_moe_layers
             z_norm = z_loss / n_moe_layers
             loss = (
                 loss
-                + self.config.router_aux_loss_coeff * lb_norm
+                + self.config.router_aux_loss_coeff * imp_norm
+                + self.config.router_logit_bias_coeff * bias_norm
                 + self.config.router_z_loss_coeff * z_norm
             )
 
@@ -868,7 +1477,7 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
 
             generated = torch.cat([generated, next_token], dim=1)
 
-            if next_token.item() == eos_token_id:
+            if (next_token == eos_token_id).all():
                 break
 
         return generated

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -158,6 +158,7 @@ class MoELayer(nn.Module):
 
         return shared_out + routed_out.view(B, S, D)
 
+    @torch._dynamo.disable
     def _dispatch_experts(
         self, flat_x: Tensor, flat_indices: Tensor, flat_weights: Tensor, D: int,
     ) -> Tensor:
@@ -166,6 +167,11 @@ class MoELayer(nn.Module):
         Instead of looping over top_k × num_experts (22 iterations), this
         sorts tokens by expert assignment and runs each expert on its full
         batch in a single call.
+
+        @torch._dynamo.disable: per-expert batch size is data-dependent,
+        which causes torch.compile to exceed its recompile_limit and fall
+        back to full-graph eager. Keeping only this method in eager lets
+        the rest of the model (attention, dense FFN, RoPE) stay compiled.
         """
         N = flat_x.shape[0]  # B*S
 
@@ -214,9 +220,13 @@ class MoELayer(nn.Module):
         Losses are stored on separate attributes so the training loss can
         apply router_aux_loss_coeff and router_z_loss_coeff independently.
         """
-        # Fraction of tokens routed to each expert
-        one_hot = F.one_hot(top_k_indices, self.num_routed).float()  # (B, S, top_k, num_routed)
-        tokens_per_expert = one_hot.sum(dim=(0, 1, 2))  # (num_routed,)
+        # Fraction of tokens routed to each expert — bincount avoids the
+        # (B, S, top_k, num_routed) one-hot allocation which spikes memory
+        # at seq_len 4096/8192. Cast is needed because bincount returns int.
+        flat_indices = top_k_indices.reshape(-1)  # (B * S * top_k,)
+        tokens_per_expert = torch.bincount(
+            flat_indices, minlength=self.num_routed
+        ).to(router_probs.dtype)
         fraction_routed = tokens_per_expert / (B * S * self.top_k)
 
         # Average router probability per expert (sigmoid — matches gating)
@@ -475,13 +485,17 @@ class NanoOSRTv4ForCausalLM(NanoOSRTv4PreTrainedModel):
                 shift_labels.view(-1),
                 ignore_index=-100,
             )
-            # MoE losses scaled independently:
-            #   load-balance at router_aux_loss_coeff  (default 0.01)
-            #   z-loss at router_z_loss_coeff          (default 0.001)
+            # MoE losses are accumulated across all (num_blocks × recursive_loops)
+            # effective MoE applications (18 for default v4). Normalise by that
+            # count so the configured coefficient matches the per-layer weight
+            # instead of being silently multiplied by 18.
+            n_moe_layers = self.config.num_blocks * self.config.recursive_loops
+            lb_norm = lb_loss / n_moe_layers
+            z_norm = z_loss / n_moe_layers
             loss = (
                 loss
-                + self.config.router_aux_loss_coeff * lb_loss
-                + self.config.router_z_loss_coeff * z_loss
+                + self.config.router_aux_loss_coeff * lb_norm
+                + self.config.router_z_loss_coeff * z_norm
             )
 
         return CausalLMOutputWithPast(

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -120,10 +120,19 @@ class MoELayer(nn.Module):
         self.top_k = config.top_k_experts
         self.num_loops = config.recursive_loops
         self.z_loss_coeff = config.router_z_loss_coeff
-        # Additive Gaussian noise std on router logits during training.
-        # Fixes the deterministic top-2 tie-lock at init where all sigmoid
-        # probs are near 0.5 and topk always picks the first two indices.
-        self.noise_std = config.router_noise_std
+
+        # Router noise schedule. Stored as a scalar tensor buffer so
+        # torch.compile sees it as a graph input (no .item() graph break)
+        # and the training loop can update it in-place each step to
+        # implement the linear anneal from router_noise_std_init down to
+        # router_noise_std_final. Setting it to 0.0 temporarily lets the
+        # training loop run "clean" diagnostic forwards that measure
+        # learned routing without the noise perturbation.
+        self.register_buffer(
+            "noise_std",
+            torch.tensor(config.router_noise_std_init, dtype=torch.float32),
+            persistent=False,
+        )
 
         # Shared expert (always active)
         self.shared_expert = ExpertFFN(config.dim, config.expert_hidden)
@@ -208,8 +217,11 @@ class MoELayer(nn.Module):
         # Training-time router noise (Switch-Transformer style). Breaks
         # deterministic top-k tie-locking at init when all sigmoid values
         # are near 0.5 and the same two indices would win every time.
-        # Applied only in training; eval/inference uses clean logits.
-        if self.training and self.noise_std > 0:
+        # noise_std is a scalar tensor buffer — zero means clean routing,
+        # so no Python-level branching is required and torch.compile
+        # stays happy. Training loop sets it to 0.0 temporarily during
+        # diagnostic forwards to measure learned (non-random) routing.
+        if self.training:
             router_logits = router_logits + torch.randn_like(router_logits) * self.noise_std
 
         # Sigmoid gating: each expert gate is independent (DeepSeek-V3 style)

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -1,15 +1,26 @@
 """NanoOSRT v4 — Recursive MoE Model.
 
-3 physical blocks × 6 recursive loops = 18 effective layers.
-Each block: causal attention + dense SwiGLU FFN + MoE FFN (parallel residual).
-MoE: 1 shared expert (always active) + 11 routed experts (top-2).
-Loop-aware router with learned loop embeddings.
+3 physical blocks × 6 recursive loops = 18 block applications.
+Each block: causal attention (parallel adapter branch) + dense SwiGLU
+FFN + MoE FFN with parallel residual gating (dense_gate=1.0, moe_gate=0.01
+init — dense-first warmup).
+
+MoE: 1 shared expert (always active) + 11 routed experts (top-2,
+sigmoid gating). Loop-aware router adds a learned per-loop embedding
+to the hidden state before projecting (additive, not concat).
 
 HuggingFace-compatible from day one via PreTrainedModel.
 
-Physical params: ~356M (with 64K vocab)
-Active params/token: ~180M
-Effective params (recursive): ~2.1B
+Default config (32K vocab, dim=1536):
+  Physical params      : ~306M
+  Active / token (body): ~130M (shared expert + 2 of 11 routed + dense + attn)
+  Block applications    : 18    (num_blocks × recursive_loops)
+
+Note: "effective parameters" is a misleading narrative at this scale.
+The model has 306M unique weights — it just runs them 6 times per forward
+with distinct per-pass adapters and loop-conditioned routing. Think of it
+as iterative refinement on a fixed parameter budget, not a 1:1 substitute
+for a dense 1.8B model.
 """
 
 import torch

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -120,6 +120,10 @@ class MoELayer(nn.Module):
         self.top_k = config.top_k_experts
         self.num_loops = config.recursive_loops
         self.z_loss_coeff = config.router_z_loss_coeff
+        # Additive Gaussian noise std on router logits during training.
+        # Fixes the deterministic top-2 tie-lock at init where all sigmoid
+        # probs are near 0.5 and topk always picks the first two indices.
+        self.noise_std = config.router_noise_std
 
         # Shared expert (always active)
         self.shared_expert = ExpertFFN(config.dim, config.expert_hidden)
@@ -136,7 +140,17 @@ class MoELayer(nn.Module):
         # halving router params with equivalent expressive power because a
         # linear layer over cat([x, e]) can always be re-expressed as the
         # sum of two linear layers over x and e.
+        #
+        # Loop embeddings get their own larger init_std (config.loop_embedding_init_std,
+        # default 0.1) so that they actually shift routing between loops at
+        # init — the default 0.02 was too small compared to the x-signal
+        # std ~0.78, making early routing loop-invariant.
         self.loop_embeddings = nn.Embedding(config.recursive_loops, config.dim)
+        nn.init.normal_(
+            self.loop_embeddings.weight,
+            mean=0.0,
+            std=config.loop_embedding_init_std,
+        )
         self.router = nn.Linear(config.dim, self.num_routed, bias=False)
 
         # Pre-register loop index tensors to avoid torch.tensor() in forward
@@ -151,7 +165,16 @@ class MoELayer(nn.Module):
         # Per-loop telemetry — indexed [0..num_loops-1], overwritten on
         # each forward. Used by the training loop for per-loop W&B metrics.
         # Keep as plain tensors (no grad) so logging is free.
+        #
+        # router_prob_entropy: entropy of the normalised sigmoid probs. Can
+        # be near-uniform even when top-k is collapsed — not a reliable
+        # collapse detector by itself.
+        #
+        # assignment_entropy: entropy of the actual top-k token assignment
+        # distribution. Uniform routing gives ~ln(num_routed)=2.40, full
+        # top-2 collapse gives ~ln(2)=0.69. THIS is the reliable metric.
         self.last_router_entropy: list[float] = [0.0] * config.recursive_loops
+        self.last_assignment_entropy: list[float] = [0.0] * config.recursive_loops
         self.last_expert_fraction: list[list[float]] = [
             [0.0] * config.num_routed_experts for _ in range(config.recursive_loops)
         ]
@@ -182,11 +205,26 @@ class MoELayer(nn.Module):
         router_input = x + loop_emb  # (B, S, dim)
         router_logits = self.router(router_input)  # (B, S, num_routed)
 
+        # Training-time router noise (Switch-Transformer style). Breaks
+        # deterministic top-k tie-locking at init when all sigmoid values
+        # are near 0.5 and the same two indices would win every time.
+        # Applied only in training; eval/inference uses clean logits.
+        if self.training and self.noise_std > 0:
+            router_logits = router_logits + torch.randn_like(router_logits) * self.noise_std
+
         # Sigmoid gating: each expert gate is independent (DeepSeek-V3 style)
         router_probs = torch.sigmoid(router_logits)
 
-        # Top-k selection (no renormalization needed with sigmoid)
+        # Top-k selection
         top_k_weights, top_k_indices = torch.topk(router_probs, self.top_k, dim=-1)
+
+        # Renormalise the selected weights so their sum is 1.0 per token.
+        # Without this, if all sigmoid values are small (e.g. early training
+        # with low-magnitude logits) the routed MoE output magnitude is
+        # also small and gradients into the router are suppressed. With
+        # renormalisation, the routed output has a consistent scale
+        # regardless of the absolute sigmoid magnitudes.
+        top_k_weights = top_k_weights / top_k_weights.sum(dim=-1, keepdim=True).clamp_min(1e-6)
 
         # Compute load balancing + z-loss (kept separate for independent scaling)
         if self.training:
@@ -287,26 +325,42 @@ class MoELayer(nn.Module):
     def _record_telemetry(
         self, router_probs: Tensor, top_k_indices: Tensor, loop_idx: int,
     ) -> None:
-        """Record per-loop router entropy and expert-fraction histogram.
+        """Record per-loop routing telemetry.
 
         Called inside forward() during training only. Values live on CPU
-        as plain Python lists so the training loop can log them cheaply
-        without touching the compiled graph.
-        """
-        # Router entropy: how spread-out is the distribution? Low entropy
-        # means routing is collapsing (one expert dominates).
-        # Normalise sigmoid probs to a distribution first so entropy is bounded.
-        norm = router_probs / (router_probs.sum(dim=-1, keepdim=True) + 1e-8)
-        entropy = -(norm * (norm + 1e-8).log()).sum(dim=-1).mean()
-        if 0 <= loop_idx < len(self.last_router_entropy):
-            self.last_router_entropy[loop_idx] = entropy.item()
+        as plain Python lists so the training loop can log them cheaply.
 
-        # Fraction of tokens routed to each expert (top-k counts / total).
+        Two entropy metrics:
+          - router_prob_entropy: entropy of the normalised sigmoid probs.
+            CAN BE MISLEADING — near-uniform sigmoid can still produce
+            deterministic top-k (the failure mode we saw at step 200 of
+            the first sanity run).
+          - assignment_entropy: entropy of the actual top-k token
+            assignment distribution. Uniform routing over 11 experts
+            gives ~ln(11) = 2.40; full top-2 collapse gives ~ln(2) = 0.69.
+            THIS is the reliable collapse detector.
+        """
+        # 1. Router-prob entropy (kept for backwards compat + sanity)
+        norm = router_probs / (router_probs.sum(dim=-1, keepdim=True) + 1e-8)
+        prob_entropy = -(norm * (norm + 1e-8).log()).sum(dim=-1).mean()
+        if 0 <= loop_idx < len(self.last_router_entropy):
+            self.last_router_entropy[loop_idx] = prob_entropy.item()
+
+        # 2. Assignment entropy + per-expert fractions
         flat = top_k_indices.reshape(-1)
         counts = torch.bincount(flat, minlength=self.num_routed).float()
-        fractions = (counts / counts.sum().clamp_min(1)).tolist()
+        total = counts.sum().clamp_min(1)
+        fractions_tensor = counts / total
+        fractions = fractions_tensor.tolist()
         if 0 <= loop_idx < len(self.last_expert_fraction):
             self.last_expert_fraction[loop_idx] = fractions
+
+        # Entropy over the actual assignment distribution (the real metric)
+        assign_entropy = -(
+            fractions_tensor * (fractions_tensor + 1e-8).log()
+        ).sum()
+        if 0 <= loop_idx < len(self.last_assignment_entropy):
+            self.last_assignment_entropy[loop_idx] = assign_entropy.item()
 
 
 # ── Dense FFN ───────────────────────────────────────────────────────────

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -30,12 +30,31 @@ def compute_rope_freqs(
     dim: int,
     theta: float = 10000.0,
     device: torch.device | None = None,
+    scaling: dict | None = None,
 ) -> tuple[Tensor, Tensor]:
-    """Pre-compute RoPE cos/sin tensors. Shape: (1, seq_len, 1, dim)."""
+    """Pre-compute RoPE cos/sin tensors. Shape: (1, seq_len, 1, dim).
+
+    Supports optional NTK-aware scaling for extending context beyond
+    training length. Pass scaling={"type": "ntk", "factor": 4.0} in the
+    model config to extend the effective max position by ~4x at
+    inference time without retraining.
+    """
     if dim % 2 != 0:
         raise ValueError(f"RoPE requires even dimension, got dim={dim}")
+
+    # NTK-aware scaling: rescale theta so higher positions fit.
+    # factor = desired_context / training_context.
+    effective_theta = theta
+    if scaling is not None:
+        stype = scaling.get("type", "").lower()
+        factor = float(scaling.get("factor", 1.0))
+        if stype == "ntk" and factor > 1.0:
+            effective_theta = theta * (factor ** (dim / (dim - 2)))
+
     freqs = 1.0 / (
-        theta ** (torch.arange(0, dim, 2, dtype=torch.float32, device=device)[: dim // 2] / dim)
+        effective_theta ** (
+            torch.arange(0, dim, 2, dtype=torch.float32, device=device)[: dim // 2] / dim
+        )
     )
     t = torch.arange(seq_len, device=device, dtype=torch.float32)
     freqs = torch.outer(t, freqs)
@@ -118,6 +137,14 @@ class MoELayer(nn.Module):
         self.load_balance_loss: Tensor | None = None
         self.z_loss: Tensor | None = None
 
+        # Per-loop telemetry — indexed [0..num_loops-1], overwritten on
+        # each forward. Used by the training loop for per-loop W&B metrics.
+        # Keep as plain tensors (no grad) so logging is free.
+        self.last_router_entropy: list[float] = [0.0] * config.recursive_loops
+        self.last_expert_fraction: list[list[float]] = [
+            [0.0] * config.num_routed_experts for _ in range(config.recursive_loops)
+        ]
+
     def forward(self, x: Tensor, loop_idx: int) -> Tensor:
         """Forward pass through MoE.
 
@@ -153,6 +180,7 @@ class MoELayer(nn.Module):
         # Compute load balancing + z-loss (kept separate for independent scaling)
         if self.training:
             self._compute_losses(router_logits, router_probs, top_k_indices, B, S)
+            self._record_telemetry(router_probs, top_k_indices, loop_idx)
 
         # Batched scatter-gather dispatch: each expert runs exactly once
         routed_out = self._dispatch_experts(
@@ -243,6 +271,31 @@ class MoELayer(nn.Module):
         # For sigmoid routing, penalise squared logits directly (large |logit|
         # pushes sigmoid toward 0 or 1, reducing routing flexibility).
         self.z_loss = router_logits.pow(2).mean()
+
+    @torch.no_grad()
+    def _record_telemetry(
+        self, router_probs: Tensor, top_k_indices: Tensor, loop_idx: int,
+    ) -> None:
+        """Record per-loop router entropy and expert-fraction histogram.
+
+        Called inside forward() during training only. Values live on CPU
+        as plain Python lists so the training loop can log them cheaply
+        without touching the compiled graph.
+        """
+        # Router entropy: how spread-out is the distribution? Low entropy
+        # means routing is collapsing (one expert dominates).
+        # Normalise sigmoid probs to a distribution first so entropy is bounded.
+        norm = router_probs / (router_probs.sum(dim=-1, keepdim=True) + 1e-8)
+        entropy = -(norm * (norm + 1e-8).log()).sum(dim=-1).mean()
+        if 0 <= loop_idx < len(self.last_router_entropy):
+            self.last_router_entropy[loop_idx] = entropy.item()
+
+        # Fraction of tokens routed to each expert (top-k counts / total).
+        flat = top_k_indices.reshape(-1)
+        counts = torch.bincount(flat, minlength=self.num_routed).float()
+        fractions = (counts / counts.sum().clamp_min(1)).tolist()
+        if 0 <= loop_idx < len(self.last_expert_fraction):
+            self.last_expert_fraction[loop_idx] = fractions
 
 
 # ── Dense FFN ───────────────────────────────────────────────────────────
@@ -374,8 +427,16 @@ class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):
         self.config = config
         self.embedding = nn.Embedding(config.vocab_size, config.dim)
 
-        # RoPE (non-persistent buffers)
-        cos, sin = compute_rope_freqs(config.max_position_embeddings, config.head_dim, config.rope_theta)
+        # RoPE (non-persistent buffers). Optional NTK scaling extends
+        # the effective context beyond max_position_embeddings at
+        # inference time — set config.rope_scaling = {"type": "ntk",
+        # "factor": 4.0} and bump max_position_embeddings accordingly.
+        cos, sin = compute_rope_freqs(
+            config.max_position_embeddings,
+            config.head_dim,
+            config.rope_theta,
+            scaling=config.rope_scaling,
+        )
         self.register_buffer("rope_cos", cos, persistent=False)
         self.register_buffer("rope_sin", sin, persistent=False)
 

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -150,16 +150,22 @@ class MoELayer(nn.Module):
         # linear layer over cat([x, e]) can always be re-expressed as the
         # sum of two linear layers over x and e.
         #
-        # Loop embeddings get their own larger init_std (config.loop_embedding_init_std,
-        # default 0.1) so that they actually shift routing between loops at
-        # init — the default 0.02 was too small compared to the x-signal
-        # std ~0.78, making early routing loop-invariant.
+        # Loop embeddings get their own larger init_std
+        # (config.loop_embedding_init_std, default 0.1) so that they
+        # actually shift routing between loops at init — the default
+        # 0.02 was too small compared to the x-signal std ~0.78, making
+        # early routing loop-invariant.
+        #
+        # NOTE: HF PreTrainedModel.post_init() walks the module tree and
+        # calls _init_weights on every nn.Embedding with
+        # initializer_range (default 0.02), which would silently stomp
+        # whatever we set here. We tag this embedding with
+        # _osrt_init_std so the overridden _init_weights in
+        # NanoOSRTv4PreTrainedModel uses config.loop_embedding_init_std
+        # instead. Do NOT call nn.init.normal_ here — post_init will
+        # overwrite it anyway; the tag is what actually takes effect.
         self.loop_embeddings = nn.Embedding(config.recursive_loops, config.dim)
-        nn.init.normal_(
-            self.loop_embeddings.weight,
-            mean=0.0,
-            std=config.loop_embedding_init_std,
-        )
+        self.loop_embeddings._osrt_init_std = config.loop_embedding_init_std
         self.router = nn.Linear(config.dim, self.num_routed, bias=False)
 
         # Pre-register loop index tensors to avoid torch.tensor() in forward
@@ -493,7 +499,20 @@ class NanoOSRTv4PreTrainedModel(PreTrainedModel):
             if module.bias is not None:
                 nn.init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
-            nn.init.normal_(module.weight, mean=0.0, std=std)
+            # HF's post_init() walks the tree and calls _init_weights on
+            # every nn.Embedding with initializer_range (default 0.02).
+            # The MoE layer's loop_embeddings needs a LARGER init std
+            # (config.loop_embedding_init_std, default 0.1) so routing
+            # can actually differentiate across recursive loops at init.
+            # We tag that specific embedding in MoELayer.__init__ with
+            # a `_osrt_init_std` attribute so we use it here instead of
+            # the generic initializer_range.
+            custom_std = getattr(module, "_osrt_init_std", None)
+            nn.init.normal_(
+                module.weight,
+                mean=0.0,
+                std=custom_std if custom_std is not None else std,
+            )
 
 
 class NanoOSRTv4Model(NanoOSRTv4PreTrainedModel):

--- a/src/nano_osrt/v4_model.py
+++ b/src/nano_osrt/v4_model.py
@@ -99,10 +99,15 @@ class MoELayer(nn.Module):
             [ExpertFFN(config.dim, config.expert_hidden) for _ in range(self.num_routed)]
         )
 
-        # Router: projects hidden state to expert scores
-        # Loop-aware: concatenates a learned loop embedding
+        # Router: projects hidden state to expert scores.
+        # Loop-aware routing: add a learned per-loop embedding to the hidden
+        # state before the router projection. Addition (not concat) keeps
+        # router parameters at (dim -> num_routed) instead of (2*dim -> num_routed),
+        # halving router params with equivalent expressive power because a
+        # linear layer over cat([x, e]) can always be re-expressed as the
+        # sum of two linear layers over x and e.
         self.loop_embeddings = nn.Embedding(config.recursive_loops, config.dim)
-        self.router = nn.Linear(config.dim * 2, self.num_routed, bias=False)
+        self.router = nn.Linear(config.dim, self.num_routed, bias=False)
 
         # Pre-register loop index tensors to avoid torch.tensor() in forward
         self.register_buffer(
@@ -132,12 +137,11 @@ class MoELayer(nn.Module):
         # Shared expert (unconditional)
         shared_out = self.shared_expert(x)
 
-        # Loop-aware routing with cached index tensor
-        loop_emb = self.loop_embeddings(
-            self.loop_indices[loop_idx]
-        ).unsqueeze(0).unsqueeze(0).expand(B, S, -1)  # (B, S, dim)
-
-        router_input = torch.cat([x, loop_emb], dim=-1)  # (B, S, 2*dim)
+        # Loop-aware routing: add the learned per-loop embedding to x.
+        # Broadcasts (dim,) -> (B, S, dim) without materialising an
+        # expanded tensor, then router projects (dim -> num_routed).
+        loop_emb = self.loop_embeddings(self.loop_indices[loop_idx])  # (dim,)
+        router_input = x + loop_emb  # (B, S, dim)
         router_logits = self.router(router_input)  # (B, S, num_routed)
 
         # Sigmoid gating: each expert gate is independent (DeepSeek-V3 style)
@@ -287,10 +291,14 @@ class RecursiveBlockV4(nn.Module):
         self.norm_moe = nn.RMSNorm(config.dim)
         self.moe = MoELayer(config)
 
-        # Learnable gates for parallel dense + MoE residual scaling
-        # Initialised to 0.5 so combined contribution starts at 1.0×
-        self.dense_gate = nn.Parameter(torch.tensor(0.5))
-        self.moe_gate = nn.Parameter(torch.tensor(0.5))
+        # Learnable gates for parallel dense + MoE residual scaling.
+        # Init dense_gate=1.0, moe_gate=0.01 so the model starts as a
+        # (nearly) pure dense network and gradually blends in the MoE path
+        # as the router learns to route sensibly. This avoids destabilising
+        # early training with a half-random MoE contribution before the
+        # experts have specialised.
+        self.dense_gate = nn.Parameter(torch.tensor(1.0))
+        self.moe_gate = nn.Parameter(torch.tensor(0.01))
 
     def forward(
         self,
@@ -304,11 +312,15 @@ class RecursiveBlockV4(nn.Module):
     ) -> Tensor:
         B, S, D = x.shape
 
-        # Per-pass residual adapter (activation-space, not weight-LoRA)
-        x_mod = x + adapter_scale * (x @ adapter_a @ adapter_b)
+        # Per-pass residual adapter (activation-space, not weight-LoRA).
+        # Treated as a strictly additive parallel branch so the main
+        # residual stream stays clean — attention and FFN see the
+        # unadapted x, which is safer early in training when B is
+        # zero-initialised and the adapter direction is still noise.
+        adapter_out = adapter_scale * (x @ adapter_a @ adapter_b)
 
-        # ── Causal Attention with RoPE ──
-        h = self.norm_attn(x_mod)
+        # ── Causal Attention with RoPE (reads x, not x_mod) ──
+        h = self.norm_attn(x)
         qkv = self.qkv(h)
         q, k, v = qkv.chunk(3, dim=-1)
 
@@ -323,7 +335,8 @@ class RecursiveBlockV4(nn.Module):
         attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
         attn_out = attn_out.transpose(1, 2).contiguous().view(B, S, D)
 
-        x = x_mod + self.out_proj(attn_out)
+        # Attention residual + adapter (parallel branches into x)
+        x = x + self.out_proj(attn_out) + adapter_out
 
         # ── Parallel Dense + MoE FFN with learnable scaling ──
         h_dense = self.ffn_dense(self.norm_dense(x))

--- a/src/nano_osrt/v4_sft_train.py
+++ b/src/nano_osrt/v4_sft_train.py
@@ -65,20 +65,28 @@ def run_v4_sft(model_config: NanoOSRTv4Config, sft_cfg, vol, tokenizer) -> None:
         hra_params = inject_hra(model, rank=sft_cfg.hra_rank, scale=sft_cfg.hra_scale,
                                 freeze_pretrained=sft_cfg.hra_freeze_pretrained)
 
-    # Load pretrained weights
+    # Load pretrained weights — SFT MUST start from a real pretrained
+    # checkpoint. Running SFT on a randomly-initialised model would waste
+    # compute and silently produce a garbage model.
     ckpt_path = sft_cfg.pretrained_checkpoint
-    if os.path.exists(ckpt_path):
-        print(f"Loading weights from {ckpt_path}...")
-        ckpt = torch.load(ckpt_path, map_location=device, weights_only=True)
-        state_dict = ckpt.get("model_state_dict", ckpt)
-        missing, unexpected = model.load_state_dict(state_dict, strict=False)
-        if missing:
-            print(f"  Missing keys: {len(missing)}")
-        if unexpected:
-            print(f"  Unexpected keys: {len(unexpected)}")
-        print("  Weights loaded.")
+    if not os.path.exists(ckpt_path):
+        raise FileNotFoundError(
+            f"SFT refuses to start: pretrained checkpoint not found at {ckpt_path}. "
+            "Run pretrain first (modal run app_v4.py --stage pretrain)."
+        )
+
+    print(f"Loading weights from {ckpt_path}...")
+    ckpt = torch.load(ckpt_path, map_location=device, weights_only=True)
+    state_dict = ckpt.get("model_state_dict", ckpt)
+    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    if missing:
+        print(f"  MISSING keys ({len(missing)}): sample {missing[:3]}")
+    if unexpected:
+        print(f"  UNEXPECTED keys ({len(unexpected)}): sample {unexpected[:3]}")
+    if not missing and not unexpected:
+        print("  Clean load: all keys matched.")
     else:
-        print(f"WARNING: Checkpoint not found: {ckpt_path}")
+        print("  Partial load: review the keys above if this is unexpected.")
 
     if sft_cfg.hra_enabled and not getattr(sft_cfg, "hra_before_load", False):
         from nano_osrt.hra import inject_hra

--- a/src/nano_osrt/v4_train.py
+++ b/src/nano_osrt/v4_train.py
@@ -399,30 +399,52 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
             tok_per_sec = eff_batch * current_seq_len / max(elapsed / max(step - start_step, 1), 1e-8)
 
             # ── MoE diagnostics (cheap, high-value for debugging) ──
-            # Pull gate values and last-seen aux losses from the compiled
-            # model via the unwrapped inner module.
+            # Pull gate values, aux losses, router entropy, and expert
+            # usage fractions from the compiled model via the unwrapped
+            # inner module. Values are per physical block and per loop.
             inner = model._orig_mod if hasattr(model, "_orig_mod") else model
             moe_metrics = {}
             try:
                 base = inner.model if hasattr(inner, "model") else inner
-                dense_gates = []
-                moe_gates = []
                 block_lb_losses = []
                 block_z_losses = []
+                all_entropies = []
+                max_fracs = []
+                min_fracs = []
                 for bi, blk in enumerate(base.blocks):
-                    dense_gates.append(blk.dense_gate.item())
-                    moe_gates.append(blk.moe_gate.item())
+                    moe_metrics[f"moe/dense_gate_b{bi}"] = blk.dense_gate.item()
+                    moe_metrics[f"moe/moe_gate_b{bi}"] = blk.moe_gate.item()
                     if blk.moe.load_balance_loss is not None:
                         block_lb_losses.append(blk.moe.load_balance_loss.item())
                     if blk.moe.z_loss is not None:
                         block_z_losses.append(blk.moe.z_loss.item())
-                for bi, (dg, mg) in enumerate(zip(dense_gates, moe_gates)):
-                    moe_metrics[f"moe/dense_gate_b{bi}"] = dg
-                    moe_metrics[f"moe/moe_gate_b{bi}"] = mg
+
+                    # Per-loop router entropy for this block
+                    for li, ent in enumerate(blk.moe.last_router_entropy):
+                        moe_metrics[f"moe/entropy_b{bi}_l{li}"] = ent
+                        all_entropies.append(ent)
+
+                    # Per-loop expert usage: track max and min fraction
+                    # (tight gap = collapsed routing, wide gap = specialisation)
+                    for li, fracs in enumerate(blk.moe.last_expert_fraction):
+                        if fracs:
+                            mx = max(fracs)
+                            mn = min(fracs)
+                            moe_metrics[f"moe/expert_max_b{bi}_l{li}"] = mx
+                            moe_metrics[f"moe/expert_min_b{bi}_l{li}"] = mn
+                            max_fracs.append(mx)
+                            min_fracs.append(mn)
+
                 if block_lb_losses:
                     moe_metrics["moe/load_balance_loss_mean"] = sum(block_lb_losses) / len(block_lb_losses)
                 if block_z_losses:
                     moe_metrics["moe/z_loss_mean"] = sum(block_z_losses) / len(block_z_losses)
+                if all_entropies:
+                    moe_metrics["moe/entropy_mean"] = sum(all_entropies) / len(all_entropies)
+                if max_fracs:
+                    moe_metrics["moe/expert_max_mean"] = sum(max_fracs) / len(max_fracs)
+                if min_fracs:
+                    moe_metrics["moe/expert_min_mean"] = sum(min_fracs) / len(min_fracs)
             except AttributeError:
                 pass  # model not fully set up yet (first step)
 

--- a/src/nano_osrt/v4_train.py
+++ b/src/nano_osrt/v4_train.py
@@ -399,30 +399,46 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
             tok_per_sec = eff_batch * current_seq_len / max(elapsed / max(step - start_step, 1), 1e-8)
 
             # ── MoE diagnostics (cheap, high-value for debugging) ──
-            # Pull gate values, aux losses, router entropy, and expert
-            # usage fractions from the compiled model via the unwrapped
-            # inner module. Values are per physical block and per loop.
+            # Pull gate values, aux losses, router entropy, expert usage
+            # fractions, and (most importantly) assignment entropy from the
+            # compiled model via the unwrapped inner module. Values are per
+            # physical block and per loop. Key summary numbers are also
+            # printed to stdout so we catch routing collapse in real time
+            # without needing the W&B dashboard.
             inner = model._orig_mod if hasattr(model, "_orig_mod") else model
             moe_metrics = {}
+            # Collected for stdout summary line
+            moe_summary = None
             try:
                 base = inner.model if hasattr(inner, "model") else inner
                 block_lb_losses = []
                 block_z_losses = []
-                all_entropies = []
+                prob_entropies = []
+                assign_entropies = []
                 max_fracs = []
                 min_fracs = []
+                dense_gates = []
+                moe_gates = []
                 for bi, blk in enumerate(base.blocks):
-                    moe_metrics[f"moe/dense_gate_b{bi}"] = blk.dense_gate.item()
-                    moe_metrics[f"moe/moe_gate_b{bi}"] = blk.moe_gate.item()
+                    dg = blk.dense_gate.item()
+                    mg = blk.moe_gate.item()
+                    dense_gates.append(dg)
+                    moe_gates.append(mg)
+                    moe_metrics[f"moe/dense_gate_b{bi}"] = dg
+                    moe_metrics[f"moe/moe_gate_b{bi}"] = mg
                     if blk.moe.load_balance_loss is not None:
                         block_lb_losses.append(blk.moe.load_balance_loss.item())
                     if blk.moe.z_loss is not None:
                         block_z_losses.append(blk.moe.z_loss.item())
 
-                    # Per-loop router entropy for this block
+                    # Per-loop router-prob entropy (can be misleading) +
+                    # per-loop assignment entropy (the real metric).
                     for li, ent in enumerate(blk.moe.last_router_entropy):
-                        moe_metrics[f"moe/entropy_b{bi}_l{li}"] = ent
-                        all_entropies.append(ent)
+                        moe_metrics[f"moe/prob_entropy_b{bi}_l{li}"] = ent
+                        prob_entropies.append(ent)
+                    for li, ent in enumerate(blk.moe.last_assignment_entropy):
+                        moe_metrics[f"moe/assign_entropy_b{bi}_l{li}"] = ent
+                        assign_entropies.append(ent)
 
                     # Per-loop expert usage: track max and min fraction
                     # (tight gap = collapsed routing, wide gap = specialisation)
@@ -435,16 +451,31 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
                             max_fracs.append(mx)
                             min_fracs.append(mn)
 
+                def _mean(xs):
+                    return sum(xs) / len(xs) if xs else 0.0
+
                 if block_lb_losses:
-                    moe_metrics["moe/load_balance_loss_mean"] = sum(block_lb_losses) / len(block_lb_losses)
+                    moe_metrics["moe/load_balance_loss_mean"] = _mean(block_lb_losses)
                 if block_z_losses:
-                    moe_metrics["moe/z_loss_mean"] = sum(block_z_losses) / len(block_z_losses)
-                if all_entropies:
-                    moe_metrics["moe/entropy_mean"] = sum(all_entropies) / len(all_entropies)
+                    moe_metrics["moe/z_loss_mean"] = _mean(block_z_losses)
+                if prob_entropies:
+                    moe_metrics["moe/prob_entropy_mean"] = _mean(prob_entropies)
+                if assign_entropies:
+                    moe_metrics["moe/assign_entropy_mean"] = _mean(assign_entropies)
                 if max_fracs:
-                    moe_metrics["moe/expert_max_mean"] = sum(max_fracs) / len(max_fracs)
+                    moe_metrics["moe/expert_max_mean"] = _mean(max_fracs)
                 if min_fracs:
-                    moe_metrics["moe/expert_min_mean"] = sum(min_fracs) / len(min_fracs)
+                    moe_metrics["moe/expert_min_mean"] = _mean(min_fracs)
+
+                moe_summary = {
+                    "assign_entropy": _mean(assign_entropies),
+                    "expert_max": _mean(max_fracs),
+                    "expert_min": _mean(min_fracs),
+                    "dense_gate": _mean(dense_gates),
+                    "moe_gate": _mean(moe_gates),
+                    "lb_loss": _mean(block_lb_losses),
+                    "z_loss": _mean(block_z_losses),
+                }
             except AttributeError:
                 pass  # model not fully set up yet (first step)
 
@@ -452,8 +483,28 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
                 f"step {step:>7d}/{train_cfg.total_steps} | "
                 f"loss {accum_loss.item():.4f} | lr {lr:.2e} | "
                 f"vram {vram_gb:.1f}GB | tok/s {tok_per_sec:,.0f} | "
-                f"phase {current_phase} | seq_len {current_seq_len}"
+                f"phase {current_phase} | seq_len {current_seq_len}",
+                flush=True,
             )
+
+            # Critical MoE health line — prints to stdout so we see
+            # routing collapse immediately in the live Modal log instead
+            # of having to check W&B. Key number is assign_entropy:
+            #   ~2.40 (ln 11) = uniform, healthy
+            #   ~2.00        = mildly concentrated
+            #   ~1.00        = collapsing
+            #   ~0.69 (ln 2) = full top-2 collapse
+            if moe_summary is not None:
+                print(
+                    f"           moe: assign_H={moe_summary['assign_entropy']:.3f} "
+                    f"max={moe_summary['expert_max']:.3f} "
+                    f"min={moe_summary['expert_min']:.3f} | "
+                    f"gates d={moe_summary['dense_gate']:.4f} "
+                    f"m={moe_summary['moe_gate']:.4f} | "
+                    f"lb={moe_summary['lb_loss']:.3f} "
+                    f"z={moe_summary['z_loss']:.3f}",
+                    flush=True,
+                )
 
             if use_wandb:
                 log_dict = {

--- a/src/nano_osrt/v4_train.py
+++ b/src/nano_osrt/v4_train.py
@@ -314,15 +314,9 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
                   f"batch: {current_batch_size} | accum: {grad_accum} | Step: {step}")
             print(f"    Datasets: {[d['name'] for d in phase_cfg['datasets']]}")
 
-            # Enable gradient checkpointing for long sequences
-            inner = model._orig_mod if hasattr(model, "_orig_mod") else model
-            if hasattr(inner, "model") and hasattr(inner.model, "gradient_checkpointing"):
-                if current_seq_len >= 4096:
-                    inner.model.gradient_checkpointing = True
-                    print("    Gradient checkpointing: ENABLED")
-                else:
-                    inner.model.gradient_checkpointing = False
-
+            # (Per-step logic below owns gradient_checkpointing toggling —
+            # it accounts for both seq_len and routing phase. No need to
+            # set it here.)
             if current_loader is not None:
                 del current_loader
             load_t = time.time()
@@ -343,12 +337,48 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
         for pg in optimizer.param_groups:
             pg["lr"] = lr
 
-        # ── Anneal router noise linearly from init to final over
-        #    router_noise_anneal_steps (default 5000). Updates the
-        #    per-MoE noise_std buffer in-place so torch.compile sees a
-        #    fresh tensor each step without recompiling.
+        # ── Routing schedule ──
+        # Three phases:
+        #   [0, soft_warmup_steps):     mode 0 (soft_all),  alpha=0
+        #   [soft_warmup, soft+blend):  mode 1 (blend),     alpha=linear 0→1
+        #   [soft+blend, ∞):            mode 2 (hard_topk), alpha=1
+        # Mode is a Python int → changing it triggers exactly two
+        # torch.compile recompilations per run, which is fine. Alpha is
+        # a scalar buffer → in-place update, no recompile.
         inner = model._orig_mod if hasattr(model, "_orig_mod") else model
         base = inner.model if hasattr(inner, "model") else inner
+        soft_steps = max(model_config.soft_warmup_steps, 0)
+        blend_steps = max(model_config.blend_anneal_steps, 0)
+        if step < soft_steps:
+            target_mode = 0
+            current_alpha = 0.0
+        elif step < soft_steps + blend_steps:
+            target_mode = 1
+            current_alpha = (
+                (step - soft_steps) / blend_steps if blend_steps > 0 else 1.0
+            )
+        else:
+            target_mode = 2
+            current_alpha = 1.0
+        routing_phase = {0: "soft", 1: "blend", 2: "hard"}[target_mode]
+        for blk in base.blocks:
+            blk.moe.routing_mode = target_mode
+            blk.moe.routing_alpha.fill_(current_alpha)
+
+        # Soft / blend phases run every routed expert on every token, which
+        # is ~num_routed× the activation memory of hard top-k. On an 80GB
+        # A100 the uncheckpointed soft pass OOMs (first run crashed at step
+        # 0 with 74GB allocated). Force gradient checkpointing on whenever
+        # routing is not fully hard; also keep it on for long seq_len phases
+        # as before. Toggling a bool triggers at most 2 torch.compile
+        # recompiles per run (soft→blend→hard boundaries).
+        need_ckpt = (target_mode != 2) or (current_seq_len >= 4096)
+        if hasattr(base, "gradient_checkpointing") and base.gradient_checkpointing != need_ckpt:
+            base.gradient_checkpointing = need_ckpt
+
+        # Legacy router noise anneal (defaults to 0.0 → 0.0). Keep the
+        # buffer update here so setting non-zero values in config still
+        # works if someone wants extra jitter during hard phase.
         ns_init = model_config.router_noise_std_init
         ns_final = model_config.router_noise_std_final
         ns_anneal = max(model_config.router_noise_anneal_steps, 1)
@@ -356,6 +386,21 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
         current_noise = ns_init + (ns_final - ns_init) * noise_progress
         for blk in base.blocks:
             blk.moe.noise_std.fill_(current_noise)
+
+        # Gumbel-top-k anneal. Linearly decay gumbel_tau from init to
+        # final over router_gumbel_anneal_steps. This is the anti
+        # deterministic-winner-lock-in pressure: while tau > 0, top-k
+        # selection is stochastic and no expert can win by tiny
+        # logit-ordering tie-breaking alone. The anneal window (default
+        # 10K) is intentionally long so the router has time to learn
+        # robust preferences before determinism returns.
+        gt_init = model_config.router_gumbel_tau_init
+        gt_final = model_config.router_gumbel_tau_final
+        gt_anneal = max(model_config.router_gumbel_anneal_steps, 1)
+        gumbel_progress = min(step / gt_anneal, 1.0)
+        current_gumbel_tau = gt_init + (gt_final - gt_init) * gumbel_progress
+        for blk in base.blocks:
+            blk.moe.gumbel_tau.fill_(current_gumbel_tau)
 
         optimizer.zero_grad(set_to_none=True)
         accum_loss = torch.tensor(0.0, device=device)
@@ -398,6 +443,15 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
         torch.nn.utils.clip_grad_norm_(model.parameters(), train_cfg.grad_clip)
         optimizer.step()
 
+        # ── Balance-bias controller: once-per-step update ──
+        # Each MoELayer has accumulated clean-biased assignment counts
+        # across all 6 recursive-loop calls (and any grad-accum
+        # micro-batches) during the just-completed forward passes. Now
+        # that the optimizer has stepped, compute one bias update per
+        # block from the aggregated counts and reset the accumulator.
+        for blk in base.blocks:
+            blk.moe.apply_balance_update()
+
         # --- Logging ---
         should_log = (
             step % train_cfg.log_interval == 0
@@ -420,17 +474,29 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
             # printed to stdout so we catch routing collapse in real time
             # without needing the W&B dashboard.
             inner = model._orig_mod if hasattr(model, "_orig_mod") else model
-            moe_metrics = {}
+            moe_metrics = {
+                "moe/routing_mode": target_mode,
+                "moe/routing_alpha": current_alpha,
+                "moe/gumbel_tau": current_gumbel_tau,
+            }
             # Collected for stdout summary line
             moe_summary = None
             try:
                 base = inner.model if hasattr(inner, "model") else inner
-                block_lb_losses = []
+                block_imp_losses = []
+                block_bias_losses = []
                 block_z_losses = []
                 prob_entropies = []
                 assign_entropies = []
+                clean_assign_entropies = []
+                raw_assign_entropies = []
                 max_fracs = []
                 min_fracs = []
+                clean_max_fracs = []
+                clean_min_fracs = []
+                raw_max_fracs = []
+                raw_min_fracs = []
+                bias_abs_maxes = []
                 dense_gates = []
                 moe_gates = []
                 for bi, blk in enumerate(base.blocks):
@@ -440,19 +506,50 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
                     moe_gates.append(mg)
                     moe_metrics[f"moe/dense_gate_b{bi}"] = dg
                     moe_metrics[f"moe/moe_gate_b{bi}"] = mg
-                    if blk.moe.load_balance_loss is not None:
-                        block_lb_losses.append(blk.moe.load_balance_loss.item())
+                    if blk.moe.importance_loss is not None:
+                        block_imp_losses.append(blk.moe.importance_loss.item())
+                    if blk.moe.logit_bias_loss is not None:
+                        block_bias_losses.append(blk.moe.logit_bias_loss.item())
                     if blk.moe.z_loss is not None:
                         block_z_losses.append(blk.moe.z_loss.item())
 
-                    # Per-loop router-prob entropy (can be misleading) +
-                    # per-loop assignment entropy (the real metric).
+                    # Per-loop softmax entropy (soft-phase primary
+                    # signal) + per-loop assignment entropy (hard-phase
+                    # primary signal; during soft phase this holds
+                    # importance entropy as a proxy).
                     for li, ent in enumerate(blk.moe.last_router_entropy):
                         moe_metrics[f"moe/prob_entropy_b{bi}_l{li}"] = ent
                         prob_entropies.append(ent)
                     for li, ent in enumerate(blk.moe.last_assignment_entropy):
                         moe_metrics[f"moe/assign_entropy_b{bi}_l{li}"] = ent
                         assign_entropies.append(ent)
+
+                    # Clean BIASED assignment entropy (inference path:
+                    # router_logits + router_balance_bias, no noise) —
+                    # the decisive health signal.
+                    for li, ent in enumerate(blk.moe.last_clean_assignment_entropy):
+                        moe_metrics[f"moe/clean_assign_entropy_b{bi}_l{li}"] = ent
+                        clean_assign_entropies.append(ent)
+
+                    # Raw assignment entropy (router_logits only, no bias,
+                    # no noise) — diagnostic. May be collapsed even
+                    # when clean_biased is healthy; that's fine if
+                    # the deployed routing path includes the bias.
+                    for li, ent in enumerate(blk.moe.last_raw_assignment_entropy):
+                        moe_metrics[f"moe/raw_assign_entropy_b{bi}_l{li}"] = ent
+                        raw_assign_entropies.append(ent)
+
+                    # Per-block bias magnitude
+                    if hasattr(blk.moe, "router_balance_bias"):
+                        bam = blk.moe.router_balance_bias.abs().max().item()
+                        bias_abs_maxes.append(bam)
+                        moe_metrics[f"moe/bias_abs_max_b{bi}"] = bam
+
+                    # Capacity-capped telemetry
+                    for li, ofr in enumerate(blk.moe.last_overflow_rate):
+                        moe_metrics[f"moe/overflow_rate_b{bi}_l{li}"] = ofr
+                    for li, apt in enumerate(blk.moe.last_assigned_per_token):
+                        moe_metrics[f"moe/assigned_per_token_b{bi}_l{li}"] = apt
 
                     # Per-loop expert usage: track max and min fraction
                     # (tight gap = collapsed routing, wide gap = specialisation)
@@ -465,77 +562,92 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
                             max_fracs.append(mx)
                             min_fracs.append(mn)
 
+                    # Clean BIASED per-loop expert usage
+                    for li, fracs in enumerate(blk.moe.last_clean_expert_fraction):
+                        if fracs:
+                            mx = max(fracs)
+                            mn = min(fracs)
+                            moe_metrics[f"moe/clean_expert_max_b{bi}_l{li}"] = mx
+                            moe_metrics[f"moe/clean_expert_min_b{bi}_l{li}"] = mn
+                            clean_max_fracs.append(mx)
+                            clean_min_fracs.append(mn)
+
+                    # RAW (unbiased) per-loop expert usage — diagnostic
+                    for li, fracs in enumerate(blk.moe.last_raw_expert_fraction):
+                        if fracs:
+                            mx = max(fracs)
+                            mn = min(fracs)
+                            moe_metrics[f"moe/raw_expert_max_b{bi}_l{li}"] = mx
+                            moe_metrics[f"moe/raw_expert_min_b{bi}_l{li}"] = mn
+                            raw_max_fracs.append(mx)
+                            raw_min_fracs.append(mn)
+
                 def _mean(xs):
                     return sum(xs) / len(xs) if xs else 0.0
 
-                if block_lb_losses:
-                    moe_metrics["moe/load_balance_loss_mean"] = _mean(block_lb_losses)
+                if block_imp_losses:
+                    moe_metrics["moe/importance_loss_mean"] = _mean(block_imp_losses)
+                if block_bias_losses:
+                    moe_metrics["moe/logit_bias_loss_mean"] = _mean(block_bias_losses)
                 if block_z_losses:
                     moe_metrics["moe/z_loss_mean"] = _mean(block_z_losses)
                 if prob_entropies:
                     moe_metrics["moe/prob_entropy_mean"] = _mean(prob_entropies)
                 if assign_entropies:
                     moe_metrics["moe/assign_entropy_mean"] = _mean(assign_entropies)
+                if clean_assign_entropies:
+                    moe_metrics["moe/clean_assign_entropy_mean"] = _mean(clean_assign_entropies)
+                if raw_assign_entropies:
+                    moe_metrics["moe/raw_assign_entropy_mean"] = _mean(raw_assign_entropies)
                 if max_fracs:
                     moe_metrics["moe/expert_max_mean"] = _mean(max_fracs)
                 if min_fracs:
                     moe_metrics["moe/expert_min_mean"] = _mean(min_fracs)
+                if clean_max_fracs:
+                    moe_metrics["moe/clean_expert_max_mean"] = _mean(clean_max_fracs)
+                if clean_min_fracs:
+                    moe_metrics["moe/clean_expert_min_mean"] = _mean(clean_min_fracs)
+                if raw_max_fracs:
+                    moe_metrics["moe/raw_expert_max_mean"] = _mean(raw_max_fracs)
+                if raw_min_fracs:
+                    moe_metrics["moe/raw_expert_min_mean"] = _mean(raw_min_fracs)
+                if bias_abs_maxes:
+                    moe_metrics["moe/bias_abs_max_mean"] = _mean(bias_abs_maxes)
 
                 moe_summary = {
                     "assign_entropy": _mean(assign_entropies),
+                    "clean_assign_entropy": _mean(clean_assign_entropies),
+                    "raw_assign_entropy": _mean(raw_assign_entropies),
+                    "prob_entropy": _mean(prob_entropies),
                     "expert_max": _mean(max_fracs),
                     "expert_min": _mean(min_fracs),
+                    "clean_expert_max": _mean(clean_max_fracs),
+                    "clean_expert_min": _mean(clean_min_fracs),
+                    "raw_expert_max": _mean(raw_max_fracs),
+                    "raw_expert_min": _mean(raw_min_fracs),
+                    "bias_abs_max": _mean(bias_abs_maxes),
                     "dense_gate": _mean(dense_gates),
                     "moe_gate": _mean(moe_gates),
-                    "lb_loss": _mean(block_lb_losses),
+                    "imp_loss": _mean(block_imp_losses),
+                    "bias_loss": _mean(block_bias_losses),
                     "z_loss": _mean(block_z_losses),
                 }
 
-                # ── Clean-routing diagnostic ──
-                # The noisy numbers above include router_noise_std
-                # perturbation, so they optimistically bias assign_H
-                # upward. Zero the noise buffers, run ONE extra forward
-                # pass on the same data (no gradients), read the
-                # telemetry, then restore the noise schedule. This
-                # gives us the "true" learned routing every log step.
-                clean_assign = None
-                clean_max = None
-                try:
-                    saved_noise = [blk.moe.noise_std.clone() for blk in base.blocks]
-                    for blk in base.blocks:
-                        blk.moe.noise_std.fill_(0.0)
-                    with torch.no_grad():
-                        _ = model(input_ids)
-                    # telemetry was refreshed by the clean forward
-                    clean_assign_entropies = []
-                    clean_max_fracs = []
-                    clean_min_fracs = []
-                    for blk in base.blocks:
-                        clean_assign_entropies.extend(blk.moe.last_assignment_entropy)
-                        for fracs in blk.moe.last_expert_fraction:
-                            if fracs:
-                                clean_max_fracs.append(max(fracs))
-                                clean_min_fracs.append(min(fracs))
-                    clean_assign = _mean(clean_assign_entropies)
-                    clean_max = _mean(clean_max_fracs)
-                    clean_min = _mean(clean_min_fracs)
-                    moe_metrics["moe/clean_assign_entropy_mean"] = clean_assign
-                    moe_metrics["moe/clean_expert_max_mean"] = clean_max
-                    moe_metrics["moe/clean_expert_min_mean"] = clean_min
-                    moe_summary["clean_assign_entropy"] = clean_assign
-                    moe_summary["clean_expert_max"] = clean_max
-                    moe_summary["clean_expert_min"] = clean_min
-                finally:
-                    # ALWAYS restore noise schedule, even if the
-                    # diagnostic forward raised.
-                    for blk, ns in zip(base.blocks, saved_noise):
-                        blk.moe.noise_std.copy_(ns)
-                    # Re-run one noisy forward to repopulate telemetry
-                    # for the next log cycle — otherwise the stored
-                    # last_* lists would reflect the clean forward and
-                    # skew the noisy training metrics next time.
-                    with torch.no_grad():
-                        _ = model(input_ids)
+                # Aggregate capacity-capped telemetry
+                all_overflow = []
+                all_assigned = []
+                all_rank = []
+                for blk in base.blocks:
+                    all_overflow.extend(blk.moe.last_overflow_rate)
+                    all_assigned.extend(blk.moe.last_assigned_per_token)
+                    all_rank.extend(blk.moe.last_candidate_rank_mean)
+                if all_overflow:
+                    moe_metrics["moe/overflow_rate_mean"] = _mean(all_overflow)
+                    moe_metrics["moe/assigned_per_token_mean"] = _mean(all_assigned)
+                    moe_metrics["moe/candidate_rank_mean"] = _mean(all_rank)
+                    moe_summary["overflow_rate"] = _mean(all_overflow)
+                    moe_summary["assigned_per_token"] = _mean(all_assigned)
+                    moe_summary["candidate_rank"] = _mean(all_rank)
             except AttributeError:
                 pass  # model not fully set up yet (first step)
 
@@ -548,39 +660,52 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
             )
 
             # Critical MoE health line — prints to stdout so we see
-            # routing collapse immediately in the live Modal log instead
-            # of having to check W&B. Key number is the CLEAN assign_H
-            # (no router noise), which reflects what the router has
-            # actually learned:
-            #   ~2.40 (ln 11) = uniform, healthy
-            #   ~2.00        = mildly concentrated
-            #   ~1.00        = collapsing
-            #   ~0.69 (ln 2) = full top-2 collapse
+            # routing collapse immediately in the live Modal log. Which
+            # metric matters depends on the routing phase:
+            #   soft phase  → prob_H (softmax entropy) is primary;
+            #                 assign_H holds importance entropy (proxy)
+            #   blend phase → both matter; assign_H is from top-k
+            #   hard phase  → assign_H is primary
             if moe_summary is not None:
-                clean_H = moe_summary.get("clean_assign_entropy", float("nan"))
-                clean_max = moe_summary.get("clean_expert_max", float("nan"))
-                clean_min = moe_summary.get("clean_expert_min", float("nan"))
-                noise_std_now = current_noise
+                assign_H = moe_summary["assign_entropy"]
+                clean_H = moe_summary["clean_assign_entropy"]
+                raw_H = moe_summary["raw_assign_entropy"]
+                prob_H = moe_summary["prob_entropy"]
+                clean_max = moe_summary["clean_expert_max"]
+                clean_min = moe_summary["clean_expert_min"]
+                raw_max = moe_summary["raw_expert_max"]
+                raw_min = moe_summary["raw_expert_min"]
+                bias_mag = moe_summary["bias_abs_max"]
+                overflow = moe_summary.get("overflow_rate", 0.0)
+                assigned_tok = moe_summary.get("assigned_per_token", 0.0)
+                cand_rank = moe_summary.get("candidate_rank", 0.0)
                 print(
-                    f"           moe: clean assign_H={clean_H:.3f} "
-                    f"max={clean_max:.3f} "
-                    f"min={clean_min:.3f} | "
-                    f"noisy assign_H={moe_summary['assign_entropy']:.3f} "
-                    f"(noise_std={noise_std_now:.3f}) | "
+                    f"           moe[{routing_phase}]: "
+                    f"capped H={clean_H:.3f} max={clean_max:.3f} min={clean_min:.3f} | "
+                    f"raw H={raw_H:.3f} max={raw_max:.3f} | "
+                    f"overflow={overflow:.4f} assigned/tok={assigned_tok:.2f} rank={cand_rank:.2f} | "
                     f"gates d={moe_summary['dense_gate']:.4f} "
                     f"m={moe_summary['moe_gate']:.4f} | "
-                    f"lb={moe_summary['lb_loss']:.3f} "
-                    f"z={moe_summary['z_loss']:.3f}",
+                    f"imp={moe_summary['imp_loss']:.3f}",
                     flush=True,
                 )
 
-                # ── Early-stop guard ──
-                # Criteria from the review: stop immediately if routing
-                # has collapsed in a way we can't recover from. We apply
-                # these to the CLEAN metrics (not the noisy training
-                # ones) and only after step 50 so random init noise
-                # doesn't trigger false alarms.
-                if step >= 50 and clean_H == clean_H:  # not NaN
+                # ── Phase-aware early-stop guard ──
+                # Judge on CLEAN metrics (deterministic top-k), not the
+                # noisy training-time ones. Gumbel noise can keep the
+                # noisy histogram healthy-looking while the clean one
+                # collapses; the clean is the real inference signal.
+                #
+                # Only enforce once we've reached hard phase AND at
+                # least 50 steps past the blend→hard boundary, so the
+                # router has some post-transition adjustment window
+                # before we start auto-aborting.
+                hard_start = soft_steps + blend_steps
+                if (
+                    target_mode == 2
+                    and step >= hard_start + 50
+                    and clean_H == clean_H  # not NaN
+                ):
                     collapse_reasons = []
                     if clean_H < 1.5:
                         collapse_reasons.append(

--- a/src/nano_osrt/v4_train.py
+++ b/src/nano_osrt/v4_train.py
@@ -343,6 +343,20 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
         for pg in optimizer.param_groups:
             pg["lr"] = lr
 
+        # ── Anneal router noise linearly from init to final over
+        #    router_noise_anneal_steps (default 5000). Updates the
+        #    per-MoE noise_std buffer in-place so torch.compile sees a
+        #    fresh tensor each step without recompiling.
+        inner = model._orig_mod if hasattr(model, "_orig_mod") else model
+        base = inner.model if hasattr(inner, "model") else inner
+        ns_init = model_config.router_noise_std_init
+        ns_final = model_config.router_noise_std_final
+        ns_anneal = max(model_config.router_noise_anneal_steps, 1)
+        noise_progress = min(step / ns_anneal, 1.0)
+        current_noise = ns_init + (ns_final - ns_init) * noise_progress
+        for blk in base.blocks:
+            blk.moe.noise_std.fill_(current_noise)
+
         optimizer.zero_grad(set_to_none=True)
         accum_loss = torch.tensor(0.0, device=device)
 
@@ -476,6 +490,52 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
                     "lb_loss": _mean(block_lb_losses),
                     "z_loss": _mean(block_z_losses),
                 }
+
+                # ── Clean-routing diagnostic ──
+                # The noisy numbers above include router_noise_std
+                # perturbation, so they optimistically bias assign_H
+                # upward. Zero the noise buffers, run ONE extra forward
+                # pass on the same data (no gradients), read the
+                # telemetry, then restore the noise schedule. This
+                # gives us the "true" learned routing every log step.
+                clean_assign = None
+                clean_max = None
+                try:
+                    saved_noise = [blk.moe.noise_std.clone() for blk in base.blocks]
+                    for blk in base.blocks:
+                        blk.moe.noise_std.fill_(0.0)
+                    with torch.no_grad():
+                        _ = model(input_ids)
+                    # telemetry was refreshed by the clean forward
+                    clean_assign_entropies = []
+                    clean_max_fracs = []
+                    clean_min_fracs = []
+                    for blk in base.blocks:
+                        clean_assign_entropies.extend(blk.moe.last_assignment_entropy)
+                        for fracs in blk.moe.last_expert_fraction:
+                            if fracs:
+                                clean_max_fracs.append(max(fracs))
+                                clean_min_fracs.append(min(fracs))
+                    clean_assign = _mean(clean_assign_entropies)
+                    clean_max = _mean(clean_max_fracs)
+                    clean_min = _mean(clean_min_fracs)
+                    moe_metrics["moe/clean_assign_entropy_mean"] = clean_assign
+                    moe_metrics["moe/clean_expert_max_mean"] = clean_max
+                    moe_metrics["moe/clean_expert_min_mean"] = clean_min
+                    moe_summary["clean_assign_entropy"] = clean_assign
+                    moe_summary["clean_expert_max"] = clean_max
+                    moe_summary["clean_expert_min"] = clean_min
+                finally:
+                    # ALWAYS restore noise schedule, even if the
+                    # diagnostic forward raised.
+                    for blk, ns in zip(base.blocks, saved_noise):
+                        blk.moe.noise_std.copy_(ns)
+                    # Re-run one noisy forward to repopulate telemetry
+                    # for the next log cycle — otherwise the stored
+                    # last_* lists would reflect the clean forward and
+                    # skew the noisy training metrics next time.
+                    with torch.no_grad():
+                        _ = model(input_ids)
             except AttributeError:
                 pass  # model not fully set up yet (first step)
 
@@ -489,22 +549,68 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
 
             # Critical MoE health line — prints to stdout so we see
             # routing collapse immediately in the live Modal log instead
-            # of having to check W&B. Key number is assign_entropy:
+            # of having to check W&B. Key number is the CLEAN assign_H
+            # (no router noise), which reflects what the router has
+            # actually learned:
             #   ~2.40 (ln 11) = uniform, healthy
             #   ~2.00        = mildly concentrated
             #   ~1.00        = collapsing
             #   ~0.69 (ln 2) = full top-2 collapse
             if moe_summary is not None:
+                clean_H = moe_summary.get("clean_assign_entropy", float("nan"))
+                clean_max = moe_summary.get("clean_expert_max", float("nan"))
+                clean_min = moe_summary.get("clean_expert_min", float("nan"))
+                noise_std_now = current_noise
                 print(
-                    f"           moe: assign_H={moe_summary['assign_entropy']:.3f} "
-                    f"max={moe_summary['expert_max']:.3f} "
-                    f"min={moe_summary['expert_min']:.3f} | "
+                    f"           moe: clean assign_H={clean_H:.3f} "
+                    f"max={clean_max:.3f} "
+                    f"min={clean_min:.3f} | "
+                    f"noisy assign_H={moe_summary['assign_entropy']:.3f} "
+                    f"(noise_std={noise_std_now:.3f}) | "
                     f"gates d={moe_summary['dense_gate']:.4f} "
                     f"m={moe_summary['moe_gate']:.4f} | "
                     f"lb={moe_summary['lb_loss']:.3f} "
                     f"z={moe_summary['z_loss']:.3f}",
                     flush=True,
                 )
+
+                # ── Early-stop guard ──
+                # Criteria from the review: stop immediately if routing
+                # has collapsed in a way we can't recover from. We apply
+                # these to the CLEAN metrics (not the noisy training
+                # ones) and only after step 50 so random init noise
+                # doesn't trigger false alarms.
+                if step >= 50 and clean_H == clean_H:  # not NaN
+                    collapse_reasons = []
+                    if clean_H < 1.5:
+                        collapse_reasons.append(
+                            f"clean assign_H {clean_H:.3f} < 1.5 (severe collapse)"
+                        )
+                    if clean_max > 0.35:
+                        collapse_reasons.append(
+                            f"clean expert_max {clean_max:.3f} > 0.35 (concentrated)"
+                        )
+                    if clean_min < 1e-5:
+                        collapse_reasons.append(
+                            f"clean expert_min {clean_min:.5f} ~ 0 (dead experts)"
+                        )
+                    if collapse_reasons:
+                        print(
+                            "\n!!! MoE ROUTING COLLAPSE DETECTED — aborting run:",
+                            flush=True,
+                        )
+                        for r in collapse_reasons:
+                            print(f"    - {r}", flush=True)
+                        print(
+                            "Saving rescue checkpoint for post-mortem and exiting.",
+                            flush=True,
+                        )
+                        save_checkpoint(model, optimizer, step, rescue_path)
+                        vol.commit()
+                        if use_wandb:
+                            wandb.log({"train/aborted": 1.0}, step=step)
+                            wandb.finish()
+                        return
 
             if use_wandb:
                 log_dict = {

--- a/src/nano_osrt/v4_train.py
+++ b/src/nano_osrt/v4_train.py
@@ -398,6 +398,34 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
             eff_batch = current_batch_size * grad_accum
             tok_per_sec = eff_batch * current_seq_len / max(elapsed / max(step - start_step, 1), 1e-8)
 
+            # ── MoE diagnostics (cheap, high-value for debugging) ──
+            # Pull gate values and last-seen aux losses from the compiled
+            # model via the unwrapped inner module.
+            inner = model._orig_mod if hasattr(model, "_orig_mod") else model
+            moe_metrics = {}
+            try:
+                base = inner.model if hasattr(inner, "model") else inner
+                dense_gates = []
+                moe_gates = []
+                block_lb_losses = []
+                block_z_losses = []
+                for bi, blk in enumerate(base.blocks):
+                    dense_gates.append(blk.dense_gate.item())
+                    moe_gates.append(blk.moe_gate.item())
+                    if blk.moe.load_balance_loss is not None:
+                        block_lb_losses.append(blk.moe.load_balance_loss.item())
+                    if blk.moe.z_loss is not None:
+                        block_z_losses.append(blk.moe.z_loss.item())
+                for bi, (dg, mg) in enumerate(zip(dense_gates, moe_gates)):
+                    moe_metrics[f"moe/dense_gate_b{bi}"] = dg
+                    moe_metrics[f"moe/moe_gate_b{bi}"] = mg
+                if block_lb_losses:
+                    moe_metrics["moe/load_balance_loss_mean"] = sum(block_lb_losses) / len(block_lb_losses)
+                if block_z_losses:
+                    moe_metrics["moe/z_loss_mean"] = sum(block_z_losses) / len(block_z_losses)
+            except AttributeError:
+                pass  # model not fully set up yet (first step)
+
             print(
                 f"step {step:>7d}/{train_cfg.total_steps} | "
                 f"loss {accum_loss.item():.4f} | lr {lr:.2e} | "
@@ -414,6 +442,7 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
                     "train/phase": current_phase,
                     "train/seq_len": current_seq_len,
                 }
+                log_dict.update(moe_metrics)
                 wandb.log(log_dict, step=step)
 
         elif step < 100:
@@ -424,10 +453,11 @@ def run_v4_training(model_config: NanoOSRTv4Config, train_cfg: V4PretrainConfig,
                 sys.stdout.flush()
 
         # --- Eval on held-out data ---
+        # Use phase-specific batch_size to avoid OOM at seq_len 4096 / 8192.
         if step > 0 and step % train_cfg.eval_interval == 0:
             eval_metrics = run_eval(
                 model, tokenizer_name, current_seq_len,
-                train_cfg.batch_size, train_cfg.eval_steps,
+                current_batch_size, train_cfg.eval_steps,
                 device, model_config.real_vocab_size,
             )
             print(

--- a/src/nano_osrt/v4_train_config.py
+++ b/src/nano_osrt/v4_train_config.py
@@ -26,7 +26,7 @@ class V4PretrainConfig:
     log_interval: int = 50
     eval_interval: int = 1_000
     eval_steps: int = 20  # number of batches per eval
-    ckpt_interval: int = 5_000
+    ckpt_interval: int = 1_000
     optimizer_name: str = "lion"
 
     # Weights & Biases

--- a/src/nano_osrt/v4_train_config.py
+++ b/src/nano_osrt/v4_train_config.py
@@ -2,11 +2,11 @@
 
 Progressive curriculum:
   Phase 1 (Foundation):  seq_len 2048, TinyStories + CodeParrot
-  Phase 2 (Knowledge):   seq_len 4096, FineWeb-Edu + StarCoder + Wikipedia
+  Phase 2 (Knowledge):   seq_len 4096, FineWeb-Edu + CodeParrot + Wikipedia
   Phase 3 (Instruction): seq_len 8192, SmolTalk + Evol-Code + OpenHermes
 
 Post-training:
-  SFT:  Balanced math + code + STEM + general
+  SFT:  Balanced math + code + STEM + general (native tag format)
   GRPO: Verifiable math rewards (retry with larger model)
 """
 
@@ -37,9 +37,11 @@ class V4PretrainConfig:
 
     # Progressive seq_len curriculum
     # Tokens per step at each phase:
-    #   Phase 1: 8 × 8 × 2048 = 131K
-    #   Phase 2: 8 × 8 × 4096 = 262K
-    #   Phase 3: 8 × 4 × 8192 = 262K (halved accum to fit VRAM)
+    #   Phase 1 (foundation, 10K steps):  8 × 8  × 2048 = 131K tok/step → ~1.3B tokens
+    #   Phase 2 (knowledge, 240K steps):  4 × 16 × 4096 = 262K tok/step → ~63B tokens
+    #   Phase 3 (instruction, 50K steps): 2 × 32 × 8192 = 524K tok/step → ~26B tokens
+    # Total budget: ~90B tokens if the full 300K schedule completes.
+    # Batch sizes reduced at longer seq_len to fit H100 80GB VRAM.
     phases: dict = {  # noqa: RUF012
         "foundation": {
             "start": 0,
@@ -111,11 +113,9 @@ class V4PretrainConfig:
         },
     }
 
-    # Estimated token budget:
-    #   Phase 1: 15K × 131K = ~2.0B tokens
-    #   Phase 2: 235K × 262K = ~61.6B tokens
-    #   Phase 3: 50K × 262K = ~13.1B tokens
-    #   Total: ~76.7B tokens (adjust steps to hit ~50B within budget)
+    # Budget note: the schedule is aspirational — the user runs in chunks as
+    # Modal credits allow. Checkpoints every 5K steps make stop/resume cheap.
+    # Any early stopping still leaves a usable model for SFT.
 
 
 class V4SFTConfig:

--- a/tests/test_v4_model.py
+++ b/tests/test_v4_model.py
@@ -1,0 +1,262 @@
+"""Smoke tests for NanoOSRT v4.
+
+Guards the things we actually care about:
+  1. Config validation is correct (too-small top_k, etc.)
+  2. Model instantiates with expected physical parameter count
+  3. Forward + backward produces finite loss
+  4. MoE aux losses and telemetry populate during training
+  5. Router and gate initialisation match the dense-first design
+  6. RoPE NTK scaling increases the effective theta
+  7. Reward extraction handles native v4 tags (<|think|>, <|answer|>)
+
+These are CPU-friendly with a tiny config so pytest runs fast.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from nano_osrt.rewards import compute_reward, extract_numeric_answer
+from nano_osrt.v4_config import NanoOSRTv4Config
+from nano_osrt.v4_model import (
+    NanoOSRTv4ForCausalLM,
+    apply_rope,
+    compute_rope_freqs,
+)
+
+
+def _tiny_config(**overrides) -> NanoOSRTv4Config:
+    base = {
+        "dim": 128,
+        "heads": 4,
+        "head_dim": 32,
+        "vocab_size": 512,
+        "real_vocab_size": 512,
+        "num_blocks": 2,
+        "recursive_loops": 3,
+        "dense_hidden": 256,
+        "num_experts": 4,
+        "num_shared_experts": 1,
+        "num_routed_experts": 3,
+        "top_k_experts": 2,
+        "expert_hidden": 128,
+        "max_position_embeddings": 64,
+    }
+    base.update(overrides)
+    return NanoOSRTv4Config(**base)
+
+
+# Config validation ----------------------------------------------------------
+
+
+def test_config_rejects_bad_top_k():
+    with pytest.raises(ValueError, match="top_k_experts"):
+        _tiny_config(top_k_experts=5, num_routed_experts=3)
+
+
+def test_config_rejects_dim_not_divisible_by_heads():
+    with pytest.raises(ValueError, match="divisible"):
+        _tiny_config(dim=127, heads=4)
+
+
+def test_default_config_uses_32k_vocab():
+    cfg = NanoOSRTv4Config()
+    assert cfg.vocab_size == 32768
+    assert cfg.real_vocab_size == 32768
+
+
+# Model build + forward/backward --------------------------------------------
+
+
+def test_model_instantiates_and_counts_params():
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    n = sum(p.numel() for p in model.parameters())
+    assert n > 0
+    assert hasattr(model, "model")
+    assert len(model.model.blocks) == cfg.num_blocks
+
+
+def test_forward_and_backward_produce_finite_loss():
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    model.train()
+    input_ids = torch.randint(0, cfg.real_vocab_size, (2, 16))
+    out = model(input_ids, labels=input_ids)
+    assert out.logits.shape == (2, 16, cfg.vocab_size)
+    assert torch.isfinite(out.loss)
+    out.loss.backward()
+    grads = [p.grad.abs().sum() for p in model.parameters() if p.grad is not None]
+    assert grads
+    assert any(g > 0 for g in grads)
+
+
+def test_forward_without_labels_returns_logits_only():
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    # Stay in train mode for the test but use torch.no_grad() so the
+    # training-only aux-loss path still runs, matching real usage.
+    input_ids = torch.randint(0, cfg.real_vocab_size, (1, 8))
+    with torch.no_grad():
+        out = model(input_ids)
+    assert out.logits.shape == (1, 8, cfg.vocab_size)
+    assert out.loss is None
+
+
+# MoE behaviour --------------------------------------------------------------
+
+
+def test_moe_aux_losses_populate_during_training():
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    model.train()
+    input_ids = torch.randint(0, cfg.real_vocab_size, (2, 16))
+    _ = model(input_ids, labels=input_ids)
+    for blk in model.model.blocks:
+        assert blk.moe.load_balance_loss is not None
+        assert blk.moe.z_loss is not None
+        assert torch.isfinite(blk.moe.load_balance_loss)
+        assert torch.isfinite(blk.moe.z_loss)
+
+
+def test_moe_telemetry_records_per_loop():
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    model.train()
+    input_ids = torch.randint(0, cfg.real_vocab_size, (2, 16))
+    _ = model(input_ids, labels=input_ids)
+    for blk in model.model.blocks:
+        # One entry per recursive loop
+        assert len(blk.moe.last_router_entropy) == cfg.recursive_loops
+        assert len(blk.moe.last_expert_fraction) == cfg.recursive_loops
+        # Entropy should be > 0 (distribution is not a point mass)
+        assert all(e > 0 for e in blk.moe.last_router_entropy)
+        # Each fraction row sums to ~1.0
+        for fracs in blk.moe.last_expert_fraction:
+            assert len(fracs) == cfg.num_routed_experts
+            assert abs(sum(fracs) - 1.0) < 1e-4
+
+
+def test_gates_initialised_dense_first():
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    for blk in model.model.blocks:
+        assert pytest.approx(blk.dense_gate.item(), abs=1e-5) == 1.0
+        assert pytest.approx(blk.moe_gate.item(), abs=1e-4) == 0.01
+
+
+def test_router_uses_additive_loop_embedding():
+    """Router input dim should be dim (not 2*dim) since we add loop_emb."""
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    for blk in model.model.blocks:
+        # (num_routed, dim) — additive router halves what cat-router would use
+        assert blk.moe.router.weight.shape == (cfg.num_routed_experts, cfg.dim)
+
+
+# Adapter placement ----------------------------------------------------------
+
+
+def test_adapter_b_is_zero_initialised():
+    """B init to zero means adapter contribution is 0 at step 0."""
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    for b in model.model.adapters_b:
+        assert torch.all(b == 0)
+
+
+# RoPE scaling ---------------------------------------------------------------
+
+
+def test_rope_base_shape():
+    cos, sin = compute_rope_freqs(seq_len=16, dim=32, theta=10000.0)
+    assert cos.shape == (1, 16, 1, 32)
+    assert sin.shape == (1, 16, 1, 32)
+
+
+def test_rope_ntk_scaling_changes_frequencies():
+    """NTK scaling with factor=4 should produce different cos/sin than no scaling."""
+    cos_base, _ = compute_rope_freqs(seq_len=16, dim=32, theta=10000.0)
+    cos_scaled, _ = compute_rope_freqs(
+        seq_len=16, dim=32, theta=10000.0,
+        scaling={"type": "ntk", "factor": 4.0},
+    )
+    # The frequencies should differ at most positions except t=0
+    assert not torch.allclose(cos_base[0, 5:], cos_scaled[0, 5:])
+
+
+def test_rope_rotation_preserves_norm():
+    """Applying RoPE shouldn't change the vector norm."""
+    cos, sin = compute_rope_freqs(seq_len=8, dim=16)
+    x = torch.randn(1, 8, 2, 16)  # (B, S, heads, head_dim)
+    y = apply_rope(x, cos, sin)
+    assert torch.allclose(x.norm(dim=-1), y.norm(dim=-1), atol=1e-5)
+
+
+# Reward extraction (v4 native tags) ----------------------------------------
+
+
+def test_extract_numeric_answer_with_native_tags():
+    completion = "<|think|>2+2 equals 4.<|/think|><|answer|>4<|/answer|>"
+    got = extract_numeric_answer(
+        completion,
+        think_close="<|/think|>",
+        answer_open="<|answer|>",
+        answer_close="<|/answer|>",
+    )
+    assert got == "4"
+
+
+def test_extract_numeric_answer_fallback_to_think_close():
+    # No answer tags, but a close-think tag — take first number after.
+    completion = "<think>Let me solve it.</think>\n42 is the answer."
+    got = extract_numeric_answer(completion)
+    assert got == "42"
+
+
+def test_extract_numeric_answer_fallback_to_last_number():
+    # No think or answer tags — fall through to "last number in text".
+    # Avoid trailing punctuation in the input because the numeric regex
+    # also consumes a trailing dot as part of a potential decimal.
+    completion = "Some reasoning. The result is 7 pigs"
+    got = extract_numeric_answer(completion)
+    assert got == "7"
+
+
+def test_compute_reward_v4_native_tags_scores_correct_answer():
+    completion = (
+        "<|think|>Step 1: compute 2+2.\n"
+        "Step 2: verify by counting.<|/think|>"
+        "<|answer|>4<|/answer|>"
+    )
+    reward, breakdown = compute_reward(
+        completion,
+        "#### 4",
+        think_open="<|think|>",
+        think_close="<|/think|>",
+        answer_open="<|answer|>",
+        answer_close="<|/answer|>",
+    )
+    assert breakdown["correct"] is True
+    assert breakdown["has_format"] is True
+    # correctness (1.0) + format (0.2) + reasoning bonus > 1.2
+    assert reward >= 1.2
+
+
+def test_compute_reward_wrong_answer_scores_zero_correctness():
+    completion = (
+        "<|think|>2+2=5<|/think|><|answer|>5<|/answer|>"
+    )
+    reward, breakdown = compute_reward(
+        completion,
+        "#### 4",
+        think_open="<|think|>",
+        think_close="<|/think|>",
+        answer_open="<|answer|>",
+        answer_close="<|/answer|>",
+    )
+    assert breakdown["correct"] is False
+    assert breakdown["correctness_reward"] == 0.0
+    # Format present but empty-ish thinking
+    assert breakdown["has_format"] is True

--- a/tests/test_v4_model.py
+++ b/tests/test_v4_model.py
@@ -129,13 +129,41 @@ def test_moe_telemetry_records_per_loop():
     for blk in model.model.blocks:
         # One entry per recursive loop
         assert len(blk.moe.last_router_entropy) == cfg.recursive_loops
+        assert len(blk.moe.last_assignment_entropy) == cfg.recursive_loops
         assert len(blk.moe.last_expert_fraction) == cfg.recursive_loops
-        # Entropy should be > 0 (distribution is not a point mass)
+        # Both entropies should be > 0 (distribution is not a point mass)
         assert all(e > 0 for e in blk.moe.last_router_entropy)
+        assert all(e > 0 for e in blk.moe.last_assignment_entropy)
         # Each fraction row sums to ~1.0
         for fracs in blk.moe.last_expert_fraction:
             assert len(fracs) == cfg.num_routed_experts
             assert abs(sum(fracs) - 1.0) < 1e-4
+
+
+def test_assignment_entropy_detects_collapse():
+    """Assignment entropy should be much lower when routing is collapsed."""
+    import math
+
+    cfg = _tiny_config(router_noise_std=0.0)  # kill noise so we can construct a deterministic fake
+    model = NanoOSRTv4ForCausalLM(cfg)
+
+    # Build a synthetic top_k_indices that picks only experts 0 and 1
+    collapsed = torch.zeros(1, 16, cfg.top_k_experts, dtype=torch.long)
+    collapsed[..., 0] = 0  # all top-1 to expert 0
+    collapsed[..., 1] = 1  # all top-2 to expert 1
+    fake_probs = torch.full((1, 16, cfg.num_routed_experts), 0.5)
+
+    moe = model.model.blocks[0].moe
+    moe._record_telemetry(fake_probs, collapsed, loop_idx=0)
+
+    # Full top-2 collapse gives exactly ln(2) = 0.693.
+    # Uniform routing over 3 routed experts gives ln(3) = 1.099.
+    # We want the collapsed case to register as strictly lower than uniform.
+    assert moe.last_assignment_entropy[0] < math.log(cfg.num_routed_experts) - 0.2
+    assert abs(moe.last_assignment_entropy[0] - math.log(2)) < 0.05
+    # Prob entropy is still near-uniform because all fake probs are equal —
+    # this is the exact "misleading" case we wanted assignment entropy to catch.
+    assert moe.last_router_entropy[0] > math.log(cfg.num_routed_experts) * 0.9
 
 
 def test_gates_initialised_dense_first():

--- a/tests/test_v4_model.py
+++ b/tests/test_v4_model.py
@@ -144,7 +144,10 @@ def test_assignment_entropy_detects_collapse():
     """Assignment entropy should be much lower when routing is collapsed."""
     import math
 
-    cfg = _tiny_config(router_noise_std=0.0)  # kill noise so we can construct a deterministic fake
+    # router_noise_std_init would be rejected as unexpected by the config,
+    # but this test calls _record_telemetry() directly with a synthetic
+    # top_k_indices tensor so forward()-path noise never enters the picture.
+    cfg = _tiny_config()
     model = NanoOSRTv4ForCausalLM(cfg)
 
     # Build a synthetic top_k_indices that picks only experts 0 and 1
@@ -181,6 +184,41 @@ def test_router_uses_additive_loop_embedding():
     for blk in model.model.blocks:
         # (num_routed, dim) — additive router halves what cat-router would use
         assert blk.moe.router.weight.shape == (cfg.num_routed_experts, cfg.dim)
+
+
+def test_loop_embedding_init_std_survives_post_init():
+    """Regression test: HF PreTrainedModel.post_init() walks the module
+    tree and re-inits every nn.Embedding with initializer_range=0.02,
+    which previously silently overwrote the larger loop-embedding init.
+    Verify that the _osrt_init_std tag is respected and the actual
+    stddev of the initialised weights matches config.loop_embedding_init_std.
+    """
+    cfg = _tiny_config(loop_embedding_init_std=0.15)
+    model = NanoOSRTv4ForCausalLM(cfg)
+    for blk in model.model.blocks:
+        w = blk.moe.loop_embeddings.weight.detach()
+        actual_std = w.std().item()
+        # With small tensors (recursive_loops × dim = 3 × 128 = 384 values)
+        # the empirical std has some sampling error, so allow 30% tolerance.
+        assert 0.7 * cfg.loop_embedding_init_std < actual_std < 1.3 * cfg.loop_embedding_init_std, (
+            f"Expected loop_embeddings std ~ {cfg.loop_embedding_init_std}, "
+            f"got {actual_std:.4f}. HF post_init probably stomped the custom init."
+        )
+        # Verify the tag is present so the custom init path is taken
+        assert getattr(blk.moe.loop_embeddings, "_osrt_init_std", None) == cfg.loop_embedding_init_std
+
+
+def test_token_embedding_still_uses_default_std():
+    """Sanity: the main token embedding should still use initializer_range,
+    not the loop-embedding std, since only loop_embeddings was tagged.
+    """
+    cfg = _tiny_config(loop_embedding_init_std=0.15, initializer_range=0.02)
+    model = NanoOSRTv4ForCausalLM(cfg)
+    w = model.model.embedding.weight.detach()
+    actual_std = w.std().item()
+    assert 0.7 * cfg.initializer_range < actual_std < 1.3 * cfg.initializer_range, (
+        f"Token embedding std expected ~ {cfg.initializer_range}, got {actual_std:.4f}"
+    )
 
 
 # Adapter placement ----------------------------------------------------------

--- a/tests/test_v4_model.py
+++ b/tests/test_v4_model.py
@@ -4,15 +4,19 @@ Guards the things we actually care about:
   1. Config validation is correct (too-small top_k, etc.)
   2. Model instantiates with expected physical parameter count
   3. Forward + backward produces finite loss
-  4. MoE aux losses and telemetry populate during training
-  5. Router and gate initialisation match the dense-first design
-  6. RoPE NTK scaling increases the effective theta
-  7. Reward extraction handles native v4 tags (<|think|>, <|answer|>)
+  4. Differentiable MoE losses + telemetry populate during training
+  5. Router row-norm init, gate init, loop-embedding init std
+  6. Routing-mode dispatch (soft / blend / hard) produces different
+     outputs and matches a reference soft weighted sum
+  7. RoPE NTK scaling increases the effective theta
+  8. Reward extraction handles native v4 tags (<|think|>, <|answer|>)
 
 These are CPU-friendly with a tiny config so pytest runs fast.
 """
 
 from __future__ import annotations
+
+import math
 
 import pytest
 import torch
@@ -114,10 +118,60 @@ def test_moe_aux_losses_populate_during_training():
     input_ids = torch.randint(0, cfg.real_vocab_size, (2, 16))
     _ = model(input_ids, labels=input_ids)
     for blk in model.model.blocks:
-        assert blk.moe.load_balance_loss is not None
+        assert blk.moe.importance_loss is not None
+        assert blk.moe.logit_bias_loss is not None
         assert blk.moe.z_loss is not None
-        assert torch.isfinite(blk.moe.load_balance_loss)
+        assert torch.isfinite(blk.moe.importance_loss)
+        assert torch.isfinite(blk.moe.logit_bias_loss)
         assert torch.isfinite(blk.moe.z_loss)
+        # importance loss is N * sum(p^2), minimum N * (1/N) = 1.0
+        # when perfectly uniform. At init it should be close to 1.0
+        # because the router (row-normalised) has minimal bias toward
+        # any expert; allow slack for sampling noise.
+        assert blk.moe.importance_loss.item() >= 0.99
+        assert blk.moe.importance_loss.item() < 2.0
+
+
+def test_importance_loss_minimum_at_uniform():
+    """Hand-compute importance loss for a crafted uniform softmax vector."""
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    moe = model.model.blocks[0].moe
+
+    # Synthetic router logits that produce an exactly uniform softmax
+    logits = torch.zeros(1, 4, cfg.num_routed_experts)
+    probs = torch.softmax(logits, dim=-1)
+    moe._compute_losses(logits, probs)
+    # N * sum((1/N)^2) = 1.0
+    assert abs(moe.importance_loss.item() - 1.0) < 1e-5
+    # Concentrated distribution: 90% on expert 0, 10% evenly across rest
+    other = 0.1 / (cfg.num_routed_experts - 1)
+    conc = torch.full((1, 4, cfg.num_routed_experts), other)
+    conc[..., 0] = 0.9
+    # Fake logits aren't used for importance loss computation here
+    moe._compute_losses(torch.zeros_like(conc), conc)
+    # Should be >> 1.0: ~ N * (0.9^2 + 10 * other^2)
+    expected = cfg.num_routed_experts * (0.9 ** 2 + (cfg.num_routed_experts - 1) * other ** 2)
+    assert abs(moe.importance_loss.item() - expected) < 1e-4
+    # With only 3 experts the theoretical max is ~2.445 (N=3,
+    # 0.9 on one expert). We just need "clearly above uniform (1.0)".
+    assert moe.importance_loss.item() > 2.0
+
+
+def test_router_rows_equal_norm_at_init():
+    """Router.weight rows should all have the same norm after post_init
+    thanks to the row-norm tag on the router linear layer.
+    """
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    for blk in model.model.blocks:
+        rows = blk.moe.router.weight  # (num_routed, dim)
+        norms = rows.norm(dim=1)
+        # All rows should have the same norm (equal init) — within
+        # float32 precision the deviation should be ~0.
+        assert (norms.max() - norms.min()).item() < 1e-5
+        # And the mean norm should be > 0 (we didn't zero the router).
+        assert norms.mean().item() > 0.0
 
 
 def test_moe_telemetry_records_per_loop():
@@ -141,32 +195,439 @@ def test_moe_telemetry_records_per_loop():
 
 
 def test_assignment_entropy_detects_collapse():
-    """Assignment entropy should be much lower when routing is collapsed."""
-    import math
-
-    # router_noise_std_init would be rejected as unexpected by the config,
-    # but this test calls _record_telemetry() directly with a synthetic
-    # top_k_indices tensor so forward()-path noise never enters the picture.
+    """Hard-phase telemetry assignment entropy should fall under collapse."""
     cfg = _tiny_config()
     model = NanoOSRTv4ForCausalLM(cfg)
 
-    # Build a synthetic top_k_indices that picks only experts 0 and 1
+    # Synthetic top_k_indices picking only experts 0 and 1
     collapsed = torch.zeros(1, 16, cfg.top_k_experts, dtype=torch.long)
-    collapsed[..., 0] = 0  # all top-1 to expert 0
-    collapsed[..., 1] = 1  # all top-2 to expert 1
-    fake_probs = torch.full((1, 16, cfg.num_routed_experts), 0.5)
+    collapsed[..., 0] = 0
+    collapsed[..., 1] = 1
+    # Uniform softmax probs — the "misleading" signal we want to catch
+    fake_probs = torch.full(
+        (1, 16, cfg.num_routed_experts), 1.0 / cfg.num_routed_experts
+    )
 
     moe = model.model.blocks[0].moe
-    moe._record_telemetry(fake_probs, collapsed, loop_idx=0)
+    moe._record_hard_telemetry(
+        fake_probs,
+        top_k_indices=collapsed,
+        clean_biased_indices=collapsed,
+        clean_raw_indices=collapsed,
+        loop_idx=0,
+    )
 
     # Full top-2 collapse gives exactly ln(2) = 0.693.
     # Uniform routing over 3 routed experts gives ln(3) = 1.099.
-    # We want the collapsed case to register as strictly lower than uniform.
     assert moe.last_assignment_entropy[0] < math.log(cfg.num_routed_experts) - 0.2
     assert abs(moe.last_assignment_entropy[0] - math.log(2)) < 0.05
-    # Prob entropy is still near-uniform because all fake probs are equal —
-    # this is the exact "misleading" case we wanted assignment entropy to catch.
-    assert moe.last_router_entropy[0] > math.log(cfg.num_routed_experts) * 0.9
+    # Softmax entropy is still near-uniform because all probs are equal.
+    assert moe.last_router_entropy[0] > math.log(cfg.num_routed_experts) * 0.95
+
+
+def test_soft_routing_mode_uses_all_experts():
+    """In mode 0 (soft), every expert gets nonzero gradient from a single
+    forward+backward — no expert should be "dead"."""
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    model.train()
+    for blk in model.model.blocks:
+        blk.moe.routing_mode = 0
+        blk.moe.routing_alpha.fill_(0.0)
+
+    input_ids = torch.randint(0, cfg.real_vocab_size, (1, 8))
+    out = model(input_ids, labels=input_ids)
+    out.loss.backward()
+
+    # Every routed expert in every block should have nonzero gradient
+    # on its first weight matrix, because every expert ran on every token.
+    for blk in model.model.blocks:
+        for eid, expert in enumerate(blk.moe.experts):
+            g = expert.w_gate.weight.grad
+            assert g is not None, f"expert {eid} has no grad"
+            assert g.abs().sum().item() > 0.0, f"expert {eid} grad is all zeros"
+
+
+def test_balance_bias_controller_accumulate_and_apply():
+    """Accumulate skewed assignment counts, then apply a single update.
+    The over-used experts' bias should go down, the unused up, and
+    everything should be clamped. Applying without calling accumulate
+    is a no-op (accumulator is zero).
+    """
+    cfg = _tiny_config(
+        router_balance_bias_enabled=True,
+        router_balance_bias_max=0.5,
+        router_balance_bias_update_rate=0.2,
+    )
+    model = NanoOSRTv4ForCausalLM(cfg)
+    moe = model.model.blocks[0].moe
+
+    # All zero at init
+    assert torch.all(moe.router_balance_bias == 0.0)
+
+    # Skewed indices: expert 0 always picked as top-1, expert 1 as top-2
+    skewed = torch.zeros(1, 32, cfg.top_k_experts, dtype=torch.long)
+    skewed[..., 0] = 0
+    skewed[..., 1] = 1
+
+    # Accumulate multiple forward's worth of assignments (simulating
+    # the 6 recursive-loop calls in a single training step)
+    for _ in range(6):
+        moe._accumulate_balance_counts(skewed)
+
+    # Before apply: bias still zero, accumulator non-zero
+    assert torch.all(moe.router_balance_bias == 0.0)
+    assert moe.balance_total_accum.item() > 0
+
+    # Apply the update once
+    moe.apply_balance_update()
+
+    # Experts 0 and 1 should be pushed DOWN (negative bias)
+    assert moe.router_balance_bias[0].item() < 0
+    assert moe.router_balance_bias[1].item() < 0
+    # Expert 2 (unused) should be pushed UP (positive bias)
+    assert moe.router_balance_bias[2].item() > 0
+    # All clamped to [-0.5, 0.5]
+    assert moe.router_balance_bias.abs().max().item() <= 0.5 + 1e-6
+    # Accumulator has been reset
+    assert torch.all(moe.balance_count_accum == 0.0)
+    assert moe.balance_total_accum.item() == 0.0
+
+    # Multiple applies without new accumulation are safe no-ops
+    bias_before = moe.router_balance_bias.clone()
+    moe.apply_balance_update()
+    assert torch.allclose(moe.router_balance_bias, bias_before)
+
+
+def test_balance_bias_applied_in_hard_gate_selection():
+    """The balance bias should change _hard_gate's top-k selection
+    when the bias is large enough to reorder the logits.
+    """
+    cfg = _tiny_config(router_balance_bias_enabled=True)
+    model = NanoOSRTv4ForCausalLM(cfg)
+    moe = model.model.blocks[0].moe
+    moe.gumbel_tau.fill_(0.0)  # deterministic for the test
+
+    # Logits: expert 2 is highest
+    logits = torch.tensor([[[-1.0, 0.5, 2.0]]])
+
+    # With zero bias, top-2 picks [2, 1]
+    moe.router_balance_bias.zero_()
+    _, indices = moe._hard_gate(logits)
+    assert indices[0, 0].tolist() == [2, 1]
+
+    # Push expert 2 down with a large bias — now top-2 should be [1, 0]
+    moe.router_balance_bias.copy_(torch.tensor([0.0, 0.0, -5.0]))
+    _, indices = moe._hard_gate(logits)
+    assert indices[0, 0].tolist() == [1, 0]
+
+
+def test_balance_bias_persists_in_state_dict():
+    """router_balance_bias is a persistent buffer — it should appear
+    in state_dict and survive save/load."""
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    moe = model.model.blocks[0].moe
+    moe.router_balance_bias.copy_(torch.tensor([0.1, -0.2, 0.3]))
+
+    state = model.state_dict()
+    found = [k for k in state.keys() if "router_balance_bias" in k]
+    assert found, "router_balance_bias not in state_dict"
+
+    # Round-trip via a fresh model
+    model2 = NanoOSRTv4ForCausalLM(cfg)
+    model2.load_state_dict(state)
+    assert torch.allclose(
+        model2.model.blocks[0].moe.router_balance_bias,
+        torch.tensor([0.1, -0.2, 0.3]),
+    )
+
+
+def _reference_assign_with_caps(moe, cand_indices, cand_scores, N, capacity, device):
+    """Python-loop reference oracle for capacity-capped assignment.
+
+    Processes one expert at a time within each rank — guaranteed
+    race-free, easy to verify by inspection. Used as ground truth
+    for testing the vectorised production implementation.
+    """
+    assigned = torch.full((N, moe.top_k), -1, dtype=torch.long, device=device)
+    assigned_w = torch.zeros(N, moe.top_k, device=device)
+    expert_load = torch.zeros(moe.num_routed, dtype=torch.long, device=device)
+    slots_filled = torch.zeros(N, dtype=torch.long, device=device)
+    rank_sum = torch.zeros(N, dtype=torch.float32, device=device)
+
+    for rank in range(moe.candidate_k):
+        if (slots_filled >= moe.top_k).all():
+            break
+        eid_col = cand_indices[:, rank]
+        score_col = cand_scores[:, rank] if cand_scores is not None else None
+        for e in range(moe.num_routed):
+            remaining = capacity - expert_load[e].item()
+            if remaining <= 0:
+                continue
+            mask = (eid_col == e) & (slots_filled < moe.top_k)
+            if not mask.any():
+                continue
+            candidates = mask.nonzero(as_tuple=True)[0]
+            take = candidates[:remaining]
+            sidx = slots_filled[take]
+            assigned[take, sidx] = e
+            if score_col is not None:
+                assigned_w[take, sidx] = score_col[take].float()
+            slots_filled[take] += 1
+            rank_sum[take] += rank
+            expert_load[e] += len(take)
+    return assigned, assigned_w, slots_filled, rank_sum
+
+
+class TestCapacityCappedAssignment:
+    """Comprehensive tests for _assign_with_caps against a reference
+    oracle. Covers: overflow, assigned/tok, max bound, no duplicate
+    experts per token, rank_mean match, same selections as oracle,
+    unfilled slot masking, and bf16 autocast compatibility.
+    """
+
+    @staticmethod
+    def _make_moe(num_routed=11, top_k=2, candidate_k=11, capacity_factor=1.25):
+        cfg = _tiny_config(
+            num_routed_experts=num_routed,
+            num_experts=num_routed + 1,
+            top_k_experts=top_k,
+            router_capacity_capped=True,
+            router_candidate_k=candidate_k,
+            router_capacity_factor=capacity_factor,
+        )
+        model = NanoOSRTv4ForCausalLM(cfg)
+        return model.model.blocks[0].moe
+
+    @staticmethod
+    def _random_candidates(N, num_routed, candidate_k, device="cpu"):
+        logits = torch.randn(N, num_routed, device=device)
+        sig = torch.sigmoid(logits)
+        cand_s, cand_i = torch.topk(sig, candidate_k, dim=-1)
+        return cand_i, cand_s
+
+    @staticmethod
+    def _concentrated_candidates(N, num_routed, candidate_k, device="cpu"):
+        """All tokens strongly prefer expert 0."""
+        logits = torch.randn(N, num_routed, device=device) * 0.01
+        logits[:, 0] = 10.0
+        sig = torch.sigmoid(logits)
+        cand_s, cand_i = torch.topk(sig, candidate_k, dim=-1)
+        return cand_i, cand_s
+
+    def test_oracle_match_random_logits(self):
+        moe = self._make_moe(num_routed=3, candidate_k=3)
+        N = 512
+        cand_i, cand_s = self._random_candidates(N, 3, 3)
+        cap = math.ceil(1.25 * N * 2 / 3)
+
+        ref_a, ref_w, ref_sf, ref_rs = _reference_assign_with_caps(
+            moe, cand_i, cand_s, N, cap, torch.device("cpu"),
+        )
+        vec_a, vec_w, vec_sf, vec_rs = moe._assign_with_caps(
+            cand_i, cand_s, N, cap, torch.device("cpu"),
+        )
+        assert torch.equal(vec_a, ref_a), "assigned indices differ from oracle"
+        assert torch.allclose(vec_w, ref_w, atol=1e-6), "weights differ"
+        assert torch.equal(vec_sf, ref_sf), "slots_filled differ"
+        assert torch.equal(vec_rs.long(), ref_rs.long()), "rank_sum differ"
+
+    def test_oracle_match_concentrated_logits(self):
+        moe = self._make_moe(num_routed=3, candidate_k=3)
+        N = 512
+        cand_i, cand_s = self._concentrated_candidates(N, 3, 3)
+        cap = math.ceil(1.25 * N * 2 / 3)
+
+        ref_a, ref_w, ref_sf, ref_rs = _reference_assign_with_caps(
+            moe, cand_i, cand_s, N, cap, torch.device("cpu"),
+        )
+        vec_a, vec_w, vec_sf, vec_rs = moe._assign_with_caps(
+            cand_i, cand_s, N, cap, torch.device("cpu"),
+        )
+        assert torch.equal(vec_a, ref_a)
+        assert torch.allclose(vec_w, ref_w, atol=1e-6)
+        assert torch.equal(vec_sf, ref_sf)
+
+    def test_zero_overflow_when_candidate_k_equals_num_experts(self):
+        moe = self._make_moe(num_routed=11, candidate_k=11)
+        N = 2048
+        cand_i, cand_s = self._random_candidates(N, 11, 11)
+        cap = math.ceil(1.25 * N * 2 / 11)
+        _, _, sf, _ = moe._assign_with_caps(cand_i, cand_s, N, cap, torch.device("cpu"))
+        assert (sf == 2).all(), f"overflow: {(sf < 2).sum()} tokens unfilled"
+
+    def test_assigned_per_token_equals_top_k(self):
+        moe = self._make_moe(num_routed=11, candidate_k=11)
+        N = 2048
+        cand_i, cand_s = self._random_candidates(N, 11, 11)
+        cap = math.ceil(1.25 * N * 2 / 11)
+        _, _, sf, _ = moe._assign_with_caps(cand_i, cand_s, N, cap, torch.device("cpu"))
+        assert sf.float().mean().item() == 2.0
+
+    def test_expert_max_bounded_by_capacity(self):
+        moe = self._make_moe(num_routed=11, candidate_k=11)
+        N = 4096
+        cand_i, cand_s = self._concentrated_candidates(N, 11, 11)
+        cap = math.ceil(1.25 * N * 2 / 11)
+        assigned, _, _, _ = moe._assign_with_caps(cand_i, cand_s, N, cap, torch.device("cpu"))
+        valid = assigned[assigned >= 0]
+        counts = torch.bincount(valid, minlength=11)
+        assert counts.max().item() <= cap, f"expert got {counts.max()} > cap {cap}"
+
+    def test_no_duplicate_expert_per_token(self):
+        moe = self._make_moe(num_routed=11, candidate_k=11)
+        N = 2048
+        cand_i, cand_s = self._random_candidates(N, 11, 11)
+        cap = math.ceil(1.25 * N * 2 / 11)
+        assigned, _, sf, _ = moe._assign_with_caps(cand_i, cand_s, N, cap, torch.device("cpu"))
+        for i in range(N):
+            filled = assigned[i, :sf[i]]
+            assert filled.unique().shape[0] == sf[i], (
+                f"token {i} has duplicate expert: {filled.tolist()}"
+            )
+
+    def test_unfilled_slots_are_minus_one(self):
+        """With capacity_factor=0.5, some tokens can't fill both slots.
+        Unfilled slots should stay -1 with weight 0."""
+        moe = self._make_moe(num_routed=3, candidate_k=3, capacity_factor=0.5)
+        N = 512
+        cand_i, cand_s = self._concentrated_candidates(N, 3, 3)
+        cap = math.ceil(0.5 * N * 2 / 3)
+        assigned, assigned_w, sf, _ = moe._assign_with_caps(
+            cand_i, cand_s, N, cap, torch.device("cpu"),
+        )
+        unfilled_mask = assigned == -1
+        assert (assigned_w[unfilled_mask] == 0).all()
+        # Some tokens should have unfilled slots with factor=0.5
+        assert (sf < 2).any(), "expected some overflow with factor=0.5"
+
+    def test_scores_none_shadow_telemetry(self):
+        """When cand_scores=None (shadow path), weights should be all 0
+        and assignments should still be race-free."""
+        moe = self._make_moe(num_routed=3, candidate_k=3)
+        N = 256
+        cand_i, _ = self._random_candidates(N, 3, 3)
+        cap = math.ceil(1.25 * N * 2 / 3)
+        assigned, assigned_w, sf, _ = moe._assign_with_caps(
+            cand_i, None, N, cap, torch.device("cpu"),
+        )
+        assert (assigned_w == 0).all()
+        assert (sf == 2).all()
+
+
+def test_hard_gate_with_gumbel_noise_differs_from_clean_selection():
+    """With gumbel_tau > 0 during training, _hard_gate should produce
+    different selections across successive calls on the same logits.
+    With gumbel_tau = 0 (or eval mode), selection should be
+    deterministic.
+    """
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    moe = model.model.blocks[0].moe
+    model.train()
+
+    # Logits with a small margin so top-k isn't overwhelmingly decided
+    torch.manual_seed(0)
+    logits = torch.randn(1, 32, cfg.num_routed_experts) * 0.1
+
+    moe.gumbel_tau.fill_(1.0)
+    _, idx_a = moe._hard_gate(logits)
+    _, idx_b = moe._hard_gate(logits)
+    # Stochastic selection with tau=1.0 should diverge across calls
+    assert not torch.equal(idx_a, idx_b)
+
+    # With tau=0 selection must be deterministic
+    moe.gumbel_tau.fill_(0.0)
+    _, idx_c = moe._hard_gate(logits)
+    _, idx_d = moe._hard_gate(logits)
+    assert torch.equal(idx_c, idx_d)
+
+    # In eval mode even with tau>0 the selection should be deterministic
+    model.eval()
+    moe.gumbel_tau.fill_(1.0)
+    _, idx_e = moe._hard_gate(logits)
+    _, idx_f = moe._hard_gate(logits)
+    assert torch.equal(idx_e, idx_f)
+
+
+def test_hard_gate_weights_come_from_clean_logits_not_noised():
+    """Even when Gumbel selects different experts on different calls,
+    the returned weights should always be the CLEAN sigmoid of the
+    original logits (gathered at the chosen positions), not sigmoid of
+    the noised logits."""
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    moe = model.model.blocks[0].moe
+    model.train()
+    moe.gumbel_tau.fill_(0.0)  # deterministic for the comparison
+
+    logits = torch.tensor([[[-1.0, 0.5, 2.0]]])
+    weights, indices = moe._hard_gate(logits)
+    # top-k=2 should pick experts 2 and 1 (sigmoid of 2.0 and 0.5)
+    assert indices[0, 0].tolist() == [2, 1]
+    # Weights should be sigmoid([2.0, 0.5]) renormalized to sum to 1
+    expected_sig = torch.sigmoid(torch.tensor([2.0, 0.5]))
+    expected = expected_sig / expected_sig.sum()
+    assert torch.allclose(weights[0, 0], expected, atol=1e-5)
+
+
+def test_hard_gate_returns_topk_indices_and_renormalised_weights():
+    """Direct test of _hard_gate: top-k indices correspond to highest
+    sigmoid scores and the returned weights sum to 1 per token.
+
+    Must disable Gumbel noise (tau=0) for a deterministic comparison.
+    """
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    moe = model.model.blocks[0].moe
+    moe.gumbel_tau.fill_(0.0)  # disable Gumbel for deterministic top-k
+
+    # Hand-crafted logits: per-token argmax is expert 2 then expert 0.
+    logits = torch.tensor(
+        [[[-1.0, 0.5, 2.0], [1.0, -0.5, 0.2]]],
+    )
+    top_k_weights, top_k_indices = moe._hard_gate(logits)
+
+    # Shape checks
+    assert top_k_weights.shape == (1, 2, cfg.top_k_experts)
+    assert top_k_indices.shape == (1, 2, cfg.top_k_experts)
+    # First position: top-2 from logits (-1, 0.5, 2.0) → experts 2, 1
+    assert top_k_indices[0, 0].tolist() == [2, 1]
+    # Second position: top-2 from logits (1, -0.5, 0.2) → experts 0, 2
+    assert top_k_indices[0, 1].tolist() == [0, 2]
+    # Weights must sum to 1 along the top-k axis (renormalisation)
+    sums = top_k_weights.sum(dim=-1)
+    assert torch.allclose(sums, torch.ones_like(sums), atol=1e-5)
+
+
+def test_blend_mode_interpolates_between_soft_and_hard():
+    """With alpha=0.5 the routed output should fall between the pure
+    soft and pure hard outputs (entry-wise)."""
+    cfg = _tiny_config()
+    model = NanoOSRTv4ForCausalLM(cfg)
+    model.eval()  # deterministic, no loss computation
+    moe = model.model.blocks[0].moe
+
+    x = torch.randn(1, 4, cfg.dim)
+    with torch.no_grad():
+        moe.routing_mode = 0
+        moe.routing_alpha.fill_(0.0)
+        soft_out = moe(x, loop_idx=0)
+
+        moe.routing_mode = 2
+        moe.routing_alpha.fill_(1.0)
+        hard_out = moe(x, loop_idx=0)
+
+        moe.routing_mode = 1
+        moe.routing_alpha.fill_(0.5)
+        blend_out = moe(x, loop_idx=0)
+
+    # forward() returns shared_out + routed_out. The shared_out term is
+    # identical across all three modes, so blending the routed branches
+    # by alpha=0.5 is equivalent to averaging the full outputs.
+    expected_blend = 0.5 * soft_out + 0.5 * hard_out
+    assert torch.allclose(blend_out, expected_blend, atol=1e-4)
 
 
 def test_gates_initialised_dense_first():
@@ -419,11 +880,11 @@ class TestKVCache:
 
         torch.testing.assert_close(
             full_logits[:, 5, :], step2_out.logits[:, 0, :],
-            atol=1e-4, rtol=1e-4,
+            atol=5e-4, rtol=5e-4,
         )
         torch.testing.assert_close(
             full_logits[:, 4, :], step1_out.logits[:, 0, :],
-            atol=1e-4, rtol=1e-4,
+            atol=5e-4, rtol=5e-4,
         )
 
     def test_cache_grows_correctly(

--- a/uv.lock
+++ b/uv.lock
@@ -820,6 +820,30 @@ http = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/b5/59d16470a1f0dfe8c793f9ef56fd3826093fc52b3bd96d6b9d6c26c7e27b/gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f", size = 215371, upload-time = "2026-01-01T15:37:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/09/e21df6aef1e1ffc0c816f0522ddc3f6dcded766c3261813131c78a704470/gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058", size = 208620, upload-time = "2026-01-01T15:37:30.574Z" },
+]
+
+[[package]]
 name = "gradio"
 version = "6.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1574,6 +1598,7 @@ dependencies = [
     { name = "lm-eval" },
     { name = "modal" },
     { name = "numpy" },
+    { name = "pandas" },
     { name = "pyyaml" },
     { name = "tensorboard" },
     { name = "tiktoken" },
@@ -1581,6 +1606,7 @@ dependencies = [
     { name = "torchvision" },
     { name = "tqdm" },
     { name = "transformers" },
+    { name = "wandb" },
 ]
 
 [package.dev-dependencies]
@@ -1600,6 +1626,7 @@ requires-dist = [
     { name = "lm-eval", specifier = ">=0.4.11" },
     { name = "modal", specifier = ">=1.3.5" },
     { name = "numpy", specifier = ">=1.26.0" },
+    { name = "pandas", specifier = ">=3.0.1" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "tensorboard", specifier = ">=2.16.0" },
     { name = "tiktoken", specifier = ">=0.6.0" },
@@ -1607,6 +1634,7 @@ requires-dist = [
     { name = "torchvision", specifier = ">=0.17.0" },
     { name = "tqdm", specifier = ">=4.66.0" },
     { name = "transformers", specifier = ">=4.39.0" },
+    { name = "wandb", specifier = ">=0.25.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -2084,6 +2112,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/00/98/fc53ab36da80b88df0967896b6c4b4cd948a0dc5aa40a754266aa3ae48b3/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f975aa7ef9684ce7e2c18a3aa8f8e2106ce1e46b94ab713d156b2898811651d3", size = 5313850, upload-time = "2026-02-11T04:23:00.554Z" },
     { url = "https://files.pythonhosted.org/packages/30/02/00fa585abfd9fe9d73e5f6e554dc36cc2b842898cbfc46d70353dae227f8/pillow-12.1.1-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8089c852a56c2966cf18835db62d9b34fef7ba74c726ad943928d494fa7f4735", size = 5963343, upload-time = "2026-02-11T04:23:02.934Z" },
     { url = "https://files.pythonhosted.org/packages/f2/26/c56ce33ca856e358d27fda9676c055395abddb82c35ac0f593877ed4562e/pillow-12.1.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cb9bb857b2d057c6dfc72ac5f3b44836924ba15721882ef103cecb40d002d80e", size = 7029880, upload-time = "2026-02-11T04:23:04.783Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -2932,6 +2969,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.57.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/87/46c0406d8b5ddd026f73adaf5ab75ce144219c41a4830b52df4b9ab55f7f/sentry_sdk-2.57.0.tar.gz", hash = "sha256:4be8d1e71c32fb27f79c577a337ac8912137bba4bcbc64a4ec1da4d6d8dc5199", size = 435288, upload-time = "2026-03-31T09:39:29.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/64/982e07b93219cb52e1cca5d272cb579e2f3eb001956c9e7a9a6d106c9473/sentry_sdk-2.57.0-py2.py3-none-any.whl", hash = "sha256:812c8bf5ff3d2f0e89c82f5ce80ab3a6423e102729c4706af7413fd1eb480585", size = 456489, upload-time = "2026-03-31T09:39:27.524Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2956,6 +3006,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]
@@ -3472,6 +3531,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
+]
+
+[[package]]
+name = "wandb"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/bb/eb579bf9abac70934a014a9d4e45346aab307994f3021d201bebe5fa25ec/wandb-0.25.1.tar.gz", hash = "sha256:b2a95cd777ecbe7499599a43158834983448a0048329bc7210ef46ca18d21994", size = 43983308, upload-time = "2026-03-10T23:51:44.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/d8/873553b6818499d1b1de314067d528b892897baf0dc81fedc0e845abc2dd/wandb-0.25.1-py3-none-macosx_12_0_arm64.whl", hash = "sha256:9bb0679a3e2dcd96db9d9b6d3e17d046241d8d122974b24facb85cc93309a8c9", size = 23615900, upload-time = "2026-03-10T23:51:06.278Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ea/b131f319aaa5d0bf7572b6bfcff3dd89e1cf92b17eee443bbab71d12d74c/wandb-0.25.1-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:0fb13ed18914027523e7b4fc20380c520e0d10da0ee452f924a13f84509fbe12", size = 25576144, upload-time = "2026-03-10T23:51:11.527Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5f/81508581f0bb77b0495665c1c78e77606a48e66e855ca71ba7c8ae29efa4/wandb-0.25.1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:cc4521eb5223429ddab5e8eee9b42fdf4caabdf0bc4e0e809042720e5fbef0ed", size = 23070425, upload-time = "2026-03-10T23:51:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c7/445155ef010e2e35d190797d7c36ff441e062a5b566a6da4778e22233395/wandb-0.25.1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:e73b4c55b947edae349232d5845204d30fac88e18eb4ad1d4b96bf7cf898405a", size = 25628142, upload-time = "2026-03-10T23:51:19.326Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/63/f5c55ee00cf481ef1ccd3c385a0585ad52e7840d08419d4f82ddbeeea959/wandb-0.25.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:22b84065aa398e1624d2e5ad79e08bc4d2af41a6db61697b03b3aaba332977c6", size = 23123172, upload-time = "2026-03-10T23:51:23.418Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/19eb7974c0e9253bcbaee655222c0f0e1a52e63e9479ee711b4208f8ac31/wandb-0.25.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:005c4c6b5126ef8f4b4110e5372d950918b00637d6dc4b615ad17445f9739478", size = 25714479, upload-time = "2026-03-10T23:51:27.421Z" },
+    { url = "https://files.pythonhosted.org/packages/11/19/466c1d03323a4a0ed7d4036a59b18d6b6f67cb5032e444205927e226b18d/wandb-0.25.1-py3-none-win32.whl", hash = "sha256:8f2d04f16b88d65bfba9d79fb945f6c64e2686215469a841936e0972be8ec6a5", size = 24967338, upload-time = "2026-03-10T23:51:31.833Z" },
+    { url = "https://files.pythonhosted.org/packages/89/22/680d34c1587f3a979c701b66d71aa7c42b4ef2fdf0774f67034e618e834e/wandb-0.25.1-py3-none-win_amd64.whl", hash = "sha256:62db5166de14456156d7a85953a58733a631228e6d4248a753605f75f75fb845", size = 24967343, upload-time = "2026-03-10T23:51:36.026Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e8/76836b75d401ff5912aaf513176e64557ceaec4c4946bfd38a698ff84d48/wandb-0.25.1-py3-none-win_arm64.whl", hash = "sha256:cc7c34b70cf4b7be4d395541e82e325fd9d2be978d62c9ec01f1a7141523b6bb", size = 22080774, upload-time = "2026-03-10T23:51:40.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Capacity-capped expert routing** replacing deterministic top-k. Each expert has a hard per-batch token cap (`ceil(1.25 * N * k / E_r)`), structurally preventing routing collapse. Solves the winner lock-in problem that persisted through six prior approaches (raw top-k, soft warmup, Gumbel noise, z/bias regularisation, proportional bias controller).
- **Vectorised capacity assignment** via sort + segment-cumsum — race-free, eliminates the 121-iteration Python loop.
- **Resilient HF data loader** — auto-reconnect on stream failures instead of killing the run.
- **Bug fixes**: batched generate (.item() crash), dynamic RoPE NTK scaling, KV cache validation, bfloat16 autocast dtype, double post_init, dynamo recompile limit.
- **README**: full mathematical formulation (9 sections with LaTeX equations), updated architecture diagrams and monitoring metrics.
- **49 tests** including 8 oracle-comparison tests verifying vectorised dispatch matches the reference loop implementation.

## Routing collapse timeline

| Approach | Result |
|---|---|
| Raw deterministic top-k | Collapsed by step 30 |
| + soft warmup (all-expert) | Soft metrics healthy, hard collapsed at blend transition |
| + z-loss / logit-bias regularisation | Drove logits to zero, masked collapse |
| + Gumbel noise on selection | Noisy healthy, clean collapsed identically |
| + proportional bias controller | Engaged but oscillated, collapsed by step 40 |
| **+ capacity caps** | **Structurally bounded at 0.114 max, zero overflow, stable through 3600 steps** |

## Test plan

- [x] 49 pytest tests passing (routing, KV cache, oracle comparison, bias controller, Gumbel)
- [x] Capacity cap verified: skewed router produces max = theoretical bound, zero overflow
- [x] Vectorised dispatch matches reference loop on random + concentrated logits
- [x] Batched generate smoke test (batch_size=2)
- [x] Production run confirmed stable through soft -> blend -> hard transitions (steps 0-3600)
- [ ] Reach step 5000 checkpoint on current H100 run

🤖 Generated with [Claude Code](https://claude.com/claude-code)