### PR TITLE
🎨 Palette: Add autofocus to input and informative tooltips to generation sliders

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-02 - Gradio UI Enhancements: Autofocus and Tooltips
+**Learning:** Gradio UI components like `gr.Textbox` can immediately capture user focus using `autofocus=True`, reducing initial friction, while configuration inputs like `gr.Slider` can significantly improve discoverability with tooltips via the `info` property without cluttering the screen.
+**Action:** Consistently apply `autofocus=True` to the primary input field on interactive web apps and add explanatory `info` tooltips to technical parameters to enhance usability and accessibility.

--- a/demo.py
+++ b/demo.py
@@ -92,9 +92,9 @@ def generate_stream(
 
     with torch.no_grad():
         for i in range(max_tokens):
-            context = generated[:, -MODEL.config.seq_len:]
+            context = generated[:, -MODEL.config.seq_len :]
             out = MODEL.forward(context)
-            next_logits = out["logits"][:, -1, :MODEL.config.real_vocab_size].float()
+            next_logits = out["logits"][:, -1, : MODEL.config.real_vocab_size].float()
 
             # Repetition penalty
             if repetition_penalty != 1.0:
@@ -109,7 +109,9 @@ def generate_stream(
                 next_logits = next_logits / temperature
 
                 if top_k > 0:
-                    topk_vals, _ = torch.topk(next_logits, min(top_k, next_logits.size(-1)))
+                    topk_vals, _ = torch.topk(
+                        next_logits, min(top_k, next_logits.size(-1))
+                    )
                     next_logits[next_logits < topk_vals[:, -1:]] = float("-inf")
 
                 sorted_logits, sorted_indices = torch.sort(next_logits, descending=True)
@@ -140,6 +142,7 @@ def generate_stream(
 
 # ── Gradio UI ───────────────────────────────────────────────────────────
 
+
 def create_demo():
     with gr.Blocks(title="NanoOSRT v3") as demo:
         gr.Markdown(
@@ -161,6 +164,7 @@ def create_demo():
                     placeholder="Ask me anything... (try code or math questions)",
                     label="Message",
                     lines=2,
+                    autofocus=True,
                 )
                 with gr.Row():
                     submit_btn = gr.Button("Send", variant="primary")
@@ -169,24 +173,44 @@ def create_demo():
             with gr.Column(scale=1):
                 gr.Markdown("### Generation Settings")
                 temperature = gr.Slider(
-                    minimum=0.0, maximum=2.0, value=0.2, step=0.05,
+                    minimum=0.0,
+                    maximum=2.0,
+                    value=0.2,
+                    step=0.05,
                     label="Temperature",
+                    info="Higher values produce more diverse outputs.",
                 )
                 top_p = gr.Slider(
-                    minimum=0.0, maximum=1.0, value=0.95, step=0.05,
+                    minimum=0.0,
+                    maximum=1.0,
+                    value=0.95,
+                    step=0.05,
                     label="Top-p",
+                    info="Nucleus sampling: only consider tokens with top p probability mass.",
                 )
                 top_k = gr.Slider(
-                    minimum=0, maximum=100, value=50, step=5,
+                    minimum=0,
+                    maximum=100,
+                    value=50,
+                    step=5,
                     label="Top-k",
+                    info="Only consider the top K tokens for generation.",
                 )
                 max_tokens = gr.Slider(
-                    minimum=32, maximum=1024, value=512, step=32,
+                    minimum=32,
+                    maximum=1024,
+                    value=512,
+                    step=32,
                     label="Max tokens",
+                    info="Maximum length of the generated response.",
                 )
                 repetition_penalty = gr.Slider(
-                    minimum=1.0, maximum=2.0, value=1.2, step=0.05,
+                    minimum=1.0,
+                    maximum=2.0,
+                    value=1.2,
+                    step=0.05,
                     label="Repetition penalty",
+                    info="Penalize repeating tokens. 1.0 means no penalty.",
                 )
 
                 gr.Markdown(
@@ -212,8 +236,16 @@ def create_demo():
             label="Try these examples",
         )
 
-        def respond(message, chat_history, display_history,
-                    temperature, top_p, top_k, max_tokens, repetition_penalty):
+        def respond(
+            message,
+            chat_history,
+            display_history,
+            temperature,
+            top_p,
+            top_k,
+            max_tokens,
+            repetition_penalty,
+        ):
             # Add user message to both histories
             chat_history = chat_history + [{"role": "user", "content": message}]
             display_history = display_history + [
@@ -224,25 +256,54 @@ def create_demo():
 
             # Stream generation
             for partial in generate_stream(
-                message, chat_history[:-1],  # exclude the user msg we just added (it's in the prompt builder)
-                temperature, top_p, top_k, max_tokens, repetition_penalty,
+                message,
+                chat_history[
+                    :-1
+                ],  # exclude the user msg we just added (it's in the prompt builder)
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
             ):
                 display_history[-1] = gr.ChatMessage(role="assistant", content=partial)
                 yield chat_history, display_history, ""
 
             # Save final assistant response to chat_history
-            final = display_history[-1].content if hasattr(display_history[-1], 'content') else ""
+            final = (
+                display_history[-1].content
+                if hasattr(display_history[-1], "content")
+                else ""
+            )
             chat_history = chat_history + [{"role": "assistant", "content": final}]
             yield chat_history, display_history, ""
 
         msg.submit(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
         submit_btn.click(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
         clear_btn.click(lambda: ([], [], ""), outputs=[chat_state, chatbot, msg])


### PR DESCRIPTION
**💡 What:**
Added `autofocus=True` to the primary message `gr.Textbox` and descriptive `info` tooltips to all the technical model configuration sliders (Temperature, Top-p, Top-k, Max tokens, Repetition penalty) in the Gradio demo application (`demo.py`).

**🎯 Why:**
This solves two key micro-UX problems:
1. **Friction:** By automatically focusing on the chat input, users can immediately start typing when the interface loads, skipping a required manual click.
2. **Discoverability & Clarity:** The generation parameters (like Top-k and Nucleus sampling) are technically dense concepts. Adding inline `info` strings explains what each slider does without cluttering the screen or requiring users to read external documentation. 

**📸 Before/After:**
*(Visual changes: Chat input now auto-focuses on load, and small 'i' info icons appear next to the generation sliders with descriptive tooltips on hover)*

**♿ Accessibility:**
* The `autofocus` attribute makes the app immediately ready for keyboard input upon load, heavily benefiting keyboard-only and screen-reader users by preventing the need to tab through the interface to find the main input. 
* Tooltips provide semantic, descriptive text that aids users in understanding technical terminology natively within the UI components.

---
*PR created automatically by Jules for task [10608947757319411824](https://jules.google.com/task/10608947757319411824) started by @CodeHalwell*