### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limit to Gradio demo

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - [Add Input Validation]
+**Vulnerability:** Missing input limit constraint in public-facing UI.
+**Learning:** By default, Gradio input elements accept any amount of text, which when passed to the model could cause Denial of Service (DoS) due to high processing time or memory exhaustion.
+**Prevention:** Apply input length validation on UI forms before processing user inputs.

--- a/demo.py
+++ b/demo.py
@@ -92,9 +92,9 @@ def generate_stream(
 
     with torch.no_grad():
         for i in range(max_tokens):
-            context = generated[:, -MODEL.config.seq_len:]
+            context = generated[:, -MODEL.config.seq_len :]
             out = MODEL.forward(context)
-            next_logits = out["logits"][:, -1, :MODEL.config.real_vocab_size].float()
+            next_logits = out["logits"][:, -1, : MODEL.config.real_vocab_size].float()
 
             # Repetition penalty
             if repetition_penalty != 1.0:
@@ -109,7 +109,9 @@ def generate_stream(
                 next_logits = next_logits / temperature
 
                 if top_k > 0:
-                    topk_vals, _ = torch.topk(next_logits, min(top_k, next_logits.size(-1)))
+                    topk_vals, _ = torch.topk(
+                        next_logits, min(top_k, next_logits.size(-1))
+                    )
                     next_logits[next_logits < topk_vals[:, -1:]] = float("-inf")
 
                 sorted_logits, sorted_indices = torch.sort(next_logits, descending=True)
@@ -140,6 +142,7 @@ def generate_stream(
 
 # ── Gradio UI ───────────────────────────────────────────────────────────
 
+
 def create_demo():
     with gr.Blocks(title="NanoOSRT v3") as demo:
         gr.Markdown(
@@ -169,23 +172,38 @@ def create_demo():
             with gr.Column(scale=1):
                 gr.Markdown("### Generation Settings")
                 temperature = gr.Slider(
-                    minimum=0.0, maximum=2.0, value=0.2, step=0.05,
+                    minimum=0.0,
+                    maximum=2.0,
+                    value=0.2,
+                    step=0.05,
                     label="Temperature",
                 )
                 top_p = gr.Slider(
-                    minimum=0.0, maximum=1.0, value=0.95, step=0.05,
+                    minimum=0.0,
+                    maximum=1.0,
+                    value=0.95,
+                    step=0.05,
                     label="Top-p",
                 )
                 top_k = gr.Slider(
-                    minimum=0, maximum=100, value=50, step=5,
+                    minimum=0,
+                    maximum=100,
+                    value=50,
+                    step=5,
                     label="Top-k",
                 )
                 max_tokens = gr.Slider(
-                    minimum=32, maximum=1024, value=512, step=32,
+                    minimum=32,
+                    maximum=1024,
+                    value=512,
+                    step=32,
                     label="Max tokens",
                 )
                 repetition_penalty = gr.Slider(
-                    minimum=1.0, maximum=2.0, value=1.2, step=0.05,
+                    minimum=1.0,
+                    maximum=2.0,
+                    value=1.2,
+                    step=0.05,
                     label="Repetition penalty",
                 )
 
@@ -212,8 +230,21 @@ def create_demo():
             label="Try these examples",
         )
 
-        def respond(message, chat_history, display_history,
-                    temperature, top_p, top_k, max_tokens, repetition_penalty):
+        def respond(
+            message,
+            chat_history,
+            display_history,
+            temperature,
+            top_p,
+            top_k,
+            max_tokens,
+            repetition_penalty,
+        ):
+            if len(message) > 4000:
+                raise gr.Error(
+                    "Input message too long. Please limit to 4000 characters."
+                )
+
             # Add user message to both histories
             chat_history = chat_history + [{"role": "user", "content": message}]
             display_history = display_history + [
@@ -224,25 +255,54 @@ def create_demo():
 
             # Stream generation
             for partial in generate_stream(
-                message, chat_history[:-1],  # exclude the user msg we just added (it's in the prompt builder)
-                temperature, top_p, top_k, max_tokens, repetition_penalty,
+                message,
+                chat_history[
+                    :-1
+                ],  # exclude the user msg we just added (it's in the prompt builder)
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
             ):
                 display_history[-1] = gr.ChatMessage(role="assistant", content=partial)
                 yield chat_history, display_history, ""
 
             # Save final assistant response to chat_history
-            final = display_history[-1].content if hasattr(display_history[-1], 'content') else ""
+            final = (
+                display_history[-1].content
+                if hasattr(display_history[-1], "content")
+                else ""
+            )
             chat_history = chat_history + [{"role": "assistant", "content": final}]
             yield chat_history, display_history, ""
 
         msg.submit(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
         submit_btn.click(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
         clear_btn.click(lambda: ([], [], ""), outputs=[chat_state, chatbot, msg])


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** The `demo.py` public-facing Gradio application accepted user inputs of unlimited length. Passing excessively large inputs to the model inference engine can lead to Denial of Service (DoS) due to CPU/GPU memory exhaustion or unreasonably long processing times.

🎯 **Impact:** A malicious user could submit an extremely large text string when the Gradio app is publicly shared (`--share`), crashing the demo or severely impacting performance for all users.

🔧 **Fix:** Added a validation check at the beginning of the `respond` function in `demo.py` that asserts the input `message` length is under 4000 characters. If the length is exceeded, it cleanly raises a `gr.Error` to display a safe, user-facing error message without processing the payload or leaking stack traces.

✅ **Verification:** Ran `uv run pytest` to ensure existing model tests pass. Code formatted and linted with `uv run ruff`. Verified the logic stops generation before any backend processing begins.

---
*PR created automatically by Jules for task [7913533308644241242](https://jules.google.com/task/7913533308644241242) started by @CodeHalwell*