### PR TITLE
🎨 Palette: Add autofocus to message input and tooltips to sliders

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-07 - Autofocus in Chat UIs
+**Learning:** Found that chat UIs without autofocus require an extra click before the user can start typing. For Gradio, `gr.Textbox` supports `autofocus=True`.
+**Action:** Always add `autofocus=True` to the primary input in chat interfaces to save users a click and improve the interaction flow.

--- a/demo.py
+++ b/demo.py
@@ -161,6 +161,7 @@ def create_demo():
                     placeholder="Ask me anything... (try code or math questions)",
                     label="Message",
                     lines=2,
+                    autofocus=True,
                 )
                 with gr.Row():
                     submit_btn = gr.Button("Send", variant="primary")
@@ -171,22 +172,27 @@ def create_demo():
                 temperature = gr.Slider(
                     minimum=0.0, maximum=2.0, value=0.2, step=0.05,
                     label="Temperature",
+                    info="Controls randomness. Lower values are more deterministic.",
                 )
                 top_p = gr.Slider(
                     minimum=0.0, maximum=1.0, value=0.95, step=0.05,
                     label="Top-p",
+                    info="Nucleus sampling. Limits choices to cumulative probability.",
                 )
                 top_k = gr.Slider(
                     minimum=0, maximum=100, value=50, step=5,
                     label="Top-k",
+                    info="Limits choices to the K most likely tokens.",
                 )
                 max_tokens = gr.Slider(
                     minimum=32, maximum=1024, value=512, step=32,
                     label="Max tokens",
+                    info="Maximum number of tokens to generate.",
                 )
                 repetition_penalty = gr.Slider(
                     minimum=1.0, maximum=2.0, value=1.2, step=0.05,
                     label="Repetition penalty",
+                    info="Penalizes repeated tokens. 1.0 means no penalty.",
                 )
 
                 gr.Markdown(


### PR DESCRIPTION
### 💡 What
Added `autofocus=True` to the primary message textbox and `info` text to the generation settings sliders in `demo.py`.

### 🎯 Why
- The autofocus on the message textbox saves the user from having to manually click into the input box when the chat loads, making the primary interaction much smoother.
- The info text on the sliders (Temperature, Top-p, Top-k, Max tokens, Repetition penalty) acts as helpful tooltips, explaining technical generation parameters in plain English and removing guesswork for the user.

### 📸 Before/After
*(Visual changes text boxes automatically gain focus and sliders now have explanatory subtext.)*

### ♿ Accessibility
Reduces cognitive load by explaining complex configuration parameters directly inline and improves keyboard navigation flow by immediately focusing the primary input element on load.

---
*PR created automatically by Jules for task [12442992876228083700](https://jules.google.com/task/12442992876228083700) started by @CodeHalwell*