### PR TITLE
🎨 Palette: Improve Demo UI with parameter tooltips and input autofocus

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-08 - Gradio Parameter Tooltips & Focus
+**Learning:** Adding `info` parameters to `gr.Slider` components greatly improves usability by providing inline tooltips without cluttering the UI, while `autofocus=True` on the primary `gr.Textbox` reduces interaction friction immediately upon page load. Both are native Gradio parameters making them easy, zero-dependency UX wins.
+**Action:** Always look for opportunities to document technical parameters inline using `info` and use `autofocus=True` for the primary chat/message input element in Gradio apps.

--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -10,9 +10,8 @@ import argparse
 
 import gradio as gr
 import torch
-from transformers import AutoTokenizer
-
 from src.nano_osrt.hf_model import NanoOSRTForCausalLM
+from transformers import AutoTokenizer
 
 # ── Model loading ───────────────────────────────────────────────────────
 
@@ -161,6 +160,7 @@ def create_demo():
                     placeholder="Ask me anything... (try code or math questions)",
                     label="Message",
                     lines=2,
+                    autofocus=True,
                 )
                 with gr.Row():
                     submit_btn = gr.Button("Send", variant="primary")
@@ -171,22 +171,27 @@ def create_demo():
                 temperature = gr.Slider(
                     minimum=0.0, maximum=2.0, value=0.2, step=0.05,
                     label="Temperature",
+                    info="Controls randomness. Higher = more creative.",
                 )
                 top_p = gr.Slider(
                     minimum=0.0, maximum=1.0, value=0.95, step=0.05,
                     label="Top-p",
+                    info="Nucleus sampling. Lower = more focused.",
                 )
                 top_k = gr.Slider(
                     minimum=0, maximum=100, value=50, step=5,
                     label="Top-k",
+                    info="Limits pool of next tokens. 0 to disable.",
                 )
                 max_tokens = gr.Slider(
                     minimum=32, maximum=1024, value=512, step=32,
                     label="Max tokens",
+                    info="Maximum length of the generated response.",
                 )
                 repetition_penalty = gr.Slider(
                     minimum=1.0, maximum=2.0, value=1.2, step=0.05,
                     label="Repetition penalty",
+                    info="Penalizes repeating tokens. >1.0 reduces loops.",
                 )
 
                 gr.Markdown(


### PR DESCRIPTION
### 💡 What
Added inline tooltips (`info` parameter) to the generation setting sliders (Temperature, Top-p, Top-k, Max tokens, Repetition penalty) and applied `autofocus=True` to the main chat input textbox in the Gradio demo interface (`archive/v3/demo.py`).

### 🎯 Why
- Technical generation parameters like "Top-p" and "Repetition penalty" can be confusing for end-users. The inline `info` tooltips immediately explain their function without cluttering the UI or requiring external documentation.
- When opening a chatbot interface, the primary user action is to type a message. `autofocus` removes the need for an initial mouse click, reducing interaction friction.

### 📸 Before/After
**Before:**
- Sliders just had labels (e.g., "Top-p").
- User had to manually click the chat box to start typing.

**After:**
- Sliders now display brief explanations below them (e.g., "Nucleus sampling. Lower = more focused.").
- The chat box is instantly focused on page load.

### ♿ Accessibility
- Providing descriptive text (`info`) helps users understand complex controls, improving cognitive accessibility.
- Autofocus reduces the amount of pointer interactions required to engage with the core function of the app, aiding keyboard navigation users.

---
*PR created automatically by Jules for task [15136256950195271264](https://jules.google.com/task/15136256950195271264) started by @CodeHalwell*