### PR TITLE
🎨 Palette: Add autofocus to chat input and helpful tooltips to generation sliders

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-09 - Gradio UI Component Configuration
+**Learning:** Gradio components like `gr.Textbox` support an `autofocus=True` attribute which immediately focuses the input field, reducing user clicks. Components like `gr.Slider` support an `info` parameter which natively handles tooltip-style helper text, making the UI more accessible and self-documenting without needing additional markdown or complex layout elements.
+**Action:** Always prefer using these native configuration arguments over building custom tooltips or workarounds to keep UI code clean and accessible.

--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -10,9 +10,8 @@ import argparse
 
 import gradio as gr
 import torch
-from transformers import AutoTokenizer
-
 from src.nano_osrt.hf_model import NanoOSRTForCausalLM
+from transformers import AutoTokenizer
 
 # ── Model loading ───────────────────────────────────────────────────────
 
@@ -92,9 +91,9 @@ def generate_stream(
 
     with torch.no_grad():
         for i in range(max_tokens):
-            context = generated[:, -MODEL.config.seq_len:]
+            context = generated[:, -MODEL.config.seq_len :]
             out = MODEL.forward(context)
-            next_logits = out["logits"][:, -1, :MODEL.config.real_vocab_size].float()
+            next_logits = out["logits"][:, -1, : MODEL.config.real_vocab_size].float()
 
             # Repetition penalty
             if repetition_penalty != 1.0:
@@ -109,7 +108,9 @@ def generate_stream(
                 next_logits = next_logits / temperature
 
                 if top_k > 0:
-                    topk_vals, _ = torch.topk(next_logits, min(top_k, next_logits.size(-1)))
+                    topk_vals, _ = torch.topk(
+                        next_logits, min(top_k, next_logits.size(-1))
+                    )
                     next_logits[next_logits < topk_vals[:, -1:]] = float("-inf")
 
                 sorted_logits, sorted_indices = torch.sort(next_logits, descending=True)
@@ -140,6 +141,7 @@ def generate_stream(
 
 # ── Gradio UI ───────────────────────────────────────────────────────────
 
+
 def create_demo():
     with gr.Blocks(title="NanoOSRT v3") as demo:
         gr.Markdown(
@@ -161,6 +163,7 @@ def create_demo():
                     placeholder="Ask me anything... (try code or math questions)",
                     label="Message",
                     lines=2,
+                    autofocus=True,
                 )
                 with gr.Row():
                     submit_btn = gr.Button("Send", variant="primary")
@@ -169,24 +172,44 @@ def create_demo():
             with gr.Column(scale=1):
                 gr.Markdown("### Generation Settings")
                 temperature = gr.Slider(
-                    minimum=0.0, maximum=2.0, value=0.2, step=0.05,
+                    minimum=0.0,
+                    maximum=2.0,
+                    value=0.2,
+                    step=0.05,
                     label="Temperature",
+                    info="Higher values make output more random",
                 )
                 top_p = gr.Slider(
-                    minimum=0.0, maximum=1.0, value=0.95, step=0.05,
+                    minimum=0.0,
+                    maximum=1.0,
+                    value=0.95,
+                    step=0.05,
                     label="Top-p",
+                    info="Limits token pool to cumulative probability (0.0 to disable)",
                 )
                 top_k = gr.Slider(
-                    minimum=0, maximum=100, value=50, step=5,
+                    minimum=0,
+                    maximum=100,
+                    value=50,
+                    step=5,
                     label="Top-k",
+                    info="Limits token pool to top K choices (0 to disable)",
                 )
                 max_tokens = gr.Slider(
-                    minimum=32, maximum=1024, value=512, step=32,
+                    minimum=32,
+                    maximum=1024,
+                    value=512,
+                    step=32,
                     label="Max tokens",
+                    info="Maximum length of the generated response",
                 )
                 repetition_penalty = gr.Slider(
-                    minimum=1.0, maximum=2.0, value=1.2, step=0.05,
+                    minimum=1.0,
+                    maximum=2.0,
+                    value=1.2,
+                    step=0.05,
                     label="Repetition penalty",
+                    info="Penalizes tokens already generated (1.0 to disable)",
                 )
 
                 gr.Markdown(
@@ -212,8 +235,16 @@ def create_demo():
             label="Try these examples",
         )
 
-        def respond(message, chat_history, display_history,
-                    temperature, top_p, top_k, max_tokens, repetition_penalty):
+        def respond(
+            message,
+            chat_history,
+            display_history,
+            temperature,
+            top_p,
+            top_k,
+            max_tokens,
+            repetition_penalty,
+        ):
             # Add user message to both histories
             chat_history = chat_history + [{"role": "user", "content": message}]
             display_history = display_history + [
@@ -224,25 +255,54 @@ def create_demo():
 
             # Stream generation
             for partial in generate_stream(
-                message, chat_history[:-1],  # exclude the user msg we just added (it's in the prompt builder)
-                temperature, top_p, top_k, max_tokens, repetition_penalty,
+                message,
+                chat_history[
+                    :-1
+                ],  # exclude the user msg we just added (it's in the prompt builder)
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
             ):
                 display_history[-1] = gr.ChatMessage(role="assistant", content=partial)
                 yield chat_history, display_history, ""
 
             # Save final assistant response to chat_history
-            final = display_history[-1].content if hasattr(display_history[-1], 'content') else ""
+            final = (
+                display_history[-1].content
+                if hasattr(display_history[-1], "content")
+                else ""
+            )
             chat_history = chat_history + [{"role": "assistant", "content": final}]
             yield chat_history, display_history, ""
 
         msg.submit(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
         submit_btn.click(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
         clear_btn.click(lambda: ([], [], ""), outputs=[chat_state, chatbot, msg])


### PR DESCRIPTION
### 💡 What
Added `autofocus=True` to the chat input `gr.Textbox` and `info` descriptions to the generation settings `gr.Slider` components in the v3 demo interface. Also documented these native Gradio features in the Palette journal.

### 🎯 Why
- **Autofocus:** Users immediately want to start typing when they open the chat interface. Forcing them to click the input field first is an unnecessary friction point.
- **Tooltips (Info):** The generation settings (Temperature, Top-p, Top-k, Repetition Penalty) are highly technical. Adding brief, inline explanations helps users understand what these sliders actually do without needing to consult external documentation.

### 📸 Before/After
*N/A (Visual changes are minor helper text additions and focus states, verified via local mock app).*

### ♿ Accessibility
- `info` text on `gr.Slider` acts as an accessible description for screen readers, providing necessary context for interactive controls that might otherwise just have a technical label like "Top-p".
- `autofocus` improves keyboard navigation by immediately dropping focus into the primary interaction point of the application upon load.

---
*PR created automatically by Jules for task [10435895901197030262](https://jules.google.com/task/10435895901197030262) started by @CodeHalwell*