### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits to prevent DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Missing input length validation in Gradio UI
+**Vulnerability:** User inputs in the Gradio demo lacked length limits, allowing excessively large inputs to exhaust memory or cause a Denial of Service (DoS) during tokenization/inference.
+**Learning:** Gradio components do not enforce inherent length limits.
+**Prevention:** Always validate input string length early and raise a `gr.Error` if the payload exceeds reasonable thresholds before processing.

--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -10,9 +10,8 @@ import argparse
 
 import gradio as gr
 import torch
-from transformers import AutoTokenizer
-
 from src.nano_osrt.hf_model import NanoOSRTForCausalLM
+from transformers import AutoTokenizer
 
 # ── Model loading ───────────────────────────────────────────────────────
 
@@ -92,9 +91,9 @@ def generate_stream(
 
     with torch.no_grad():
         for i in range(max_tokens):
-            context = generated[:, -MODEL.config.seq_len:]
+            context = generated[:, -MODEL.config.seq_len :]
             out = MODEL.forward(context)
-            next_logits = out["logits"][:, -1, :MODEL.config.real_vocab_size].float()
+            next_logits = out["logits"][:, -1, : MODEL.config.real_vocab_size].float()
 
             # Repetition penalty
             if repetition_penalty != 1.0:
@@ -109,7 +108,9 @@ def generate_stream(
                 next_logits = next_logits / temperature
 
                 if top_k > 0:
-                    topk_vals, _ = torch.topk(next_logits, min(top_k, next_logits.size(-1)))
+                    topk_vals, _ = torch.topk(
+                        next_logits, min(top_k, next_logits.size(-1))
+                    )
                     next_logits[next_logits < topk_vals[:, -1:]] = float("-inf")
 
                 sorted_logits, sorted_indices = torch.sort(next_logits, descending=True)
@@ -140,6 +141,7 @@ def generate_stream(
 
 # ── Gradio UI ───────────────────────────────────────────────────────────
 
+
 def create_demo():
     with gr.Blocks(title="NanoOSRT v3") as demo:
         gr.Markdown(
@@ -169,23 +171,38 @@ def create_demo():
             with gr.Column(scale=1):
                 gr.Markdown("### Generation Settings")
                 temperature = gr.Slider(
-                    minimum=0.0, maximum=2.0, value=0.2, step=0.05,
+                    minimum=0.0,
+                    maximum=2.0,
+                    value=0.2,
+                    step=0.05,
                     label="Temperature",
                 )
                 top_p = gr.Slider(
-                    minimum=0.0, maximum=1.0, value=0.95, step=0.05,
+                    minimum=0.0,
+                    maximum=1.0,
+                    value=0.95,
+                    step=0.05,
                     label="Top-p",
                 )
                 top_k = gr.Slider(
-                    minimum=0, maximum=100, value=50, step=5,
+                    minimum=0,
+                    maximum=100,
+                    value=50,
+                    step=5,
                     label="Top-k",
                 )
                 max_tokens = gr.Slider(
-                    minimum=32, maximum=1024, value=512, step=32,
+                    minimum=32,
+                    maximum=1024,
+                    value=512,
+                    step=32,
                     label="Max tokens",
                 )
                 repetition_penalty = gr.Slider(
-                    minimum=1.0, maximum=2.0, value=1.2, step=0.05,
+                    minimum=1.0,
+                    maximum=2.0,
+                    value=1.2,
+                    step=0.05,
                     label="Repetition penalty",
                 )
 
@@ -212,8 +229,21 @@ def create_demo():
             label="Try these examples",
         )
 
-        def respond(message, chat_history, display_history,
-                    temperature, top_p, top_k, max_tokens, repetition_penalty):
+        def respond(
+            message,
+            chat_history,
+            display_history,
+            temperature,
+            top_p,
+            top_k,
+            max_tokens,
+            repetition_penalty,
+        ):
+            # Prevent Denial of Service (DoS) and memory exhaustion
+            if len(message) > 4000:
+                raise gr.Error(
+                    "Message too long! Please keep it under 4000 characters."
+                )
             # Add user message to both histories
             chat_history = chat_history + [{"role": "user", "content": message}]
             display_history = display_history + [
@@ -224,25 +254,54 @@ def create_demo():
 
             # Stream generation
             for partial in generate_stream(
-                message, chat_history[:-1],  # exclude the user msg we just added (it's in the prompt builder)
-                temperature, top_p, top_k, max_tokens, repetition_penalty,
+                message,
+                chat_history[
+                    :-1
+                ],  # exclude the user msg we just added (it's in the prompt builder)
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
             ):
                 display_history[-1] = gr.ChatMessage(role="assistant", content=partial)
                 yield chat_history, display_history, ""
 
             # Save final assistant response to chat_history
-            final = display_history[-1].content if hasattr(display_history[-1], 'content') else ""
+            final = (
+                display_history[-1].content
+                if hasattr(display_history[-1], "content")
+                else ""
+            )
             chat_history = chat_history + [{"role": "assistant", "content": final}]
             yield chat_history, display_history, ""
 
         msg.submit(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
         submit_btn.click(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
         clear_btn.click(lambda: ([], [], ""), outputs=[chat_state, chatbot, msg])

--- a/request_review.md
+++ b/request_review.md
@@ -1,0 +1,22 @@
+## Plan to fix Gradio input length limitation (Denial of Service DoS risk)
+
+Looking at the codebase and the Sentinel instructions, I identified the following:
+* **Missing input length limits (DoS risk)** is a Medium priority security issue, or we can consider it an enhancement.
+* Based on memory: "Gradio inputs (e.g., in `demo.py`) do not have inherent length limits. To prevent Denial of Service (DoS) or memory exhaustion during model inference, always explicitly validate input string lengths and raise `gr.Error` for excessively large payloads before processing."
+* The Gradio demo in `archive/v3/demo.py` takes user messages without validating length in `respond(message, ...)`. A huge input message will be encoded by the tokenizer and can lead to OOM.
+
+**Proposed solution:**
+1. Add input length validation in `archive/v3/demo.py` inside `def respond(...)`.
+2. Specifically:
+```python
+        def respond(message, chat_history, display_history,
+                    temperature, top_p, top_k, max_tokens, repetition_penalty):
+            if len(message) > 4000:
+                raise gr.Error("Message too long! Please keep it under 4000 characters.")
+            # Add user message to both histories
+            chat_history = chat_history + [{"role": "user", "content": message}]
+```
+3. Verify changes.
+4. Record critical codebase-specific security learnings in `.jules/sentinel.md`.
+
+Let me submit this plan for review.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: User inputs in the Gradio demo `archive/v3/demo.py` lacked length limits, allowing excessively large inputs to exhaust memory or cause a Denial of Service (DoS) during tokenization/inference. Gradio components do not enforce inherent length limits.
🎯 Impact: An attacker could submit extremely long strings to the Gradio chat interface, causing the server to consume excessive memory or crash.
🔧 Fix: Added explicit input length validation at the start of the `respond()` function, raising a `gr.Error` if the message exceeds 4000 characters. Also recorded this pattern in `.jules/sentinel.md`.
✅ Verification: Tested manually by attempting to submit a payload larger than 4000 characters and confirming it raises the error safely without processing. Ran linting (`ruff`) and tests (`pytest`), all pass.

---
*PR created automatically by Jules for task [13838819561240482455](https://jules.google.com/task/13838819561240482455) started by @CodeHalwell*