### PR TITLE
🛡️ Sentinel: [HIGH] Add input validation limits to Gradio chat history state

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing input length validation in Gradio UI.
 **Learning:** Gradio inputs do not have inherent length limits, allowing excessively large payloads that can lead to Denial of Service (DoS) or memory exhaustion during model inference.
 **Prevention:** Always explicitly validate input string lengths and raise `gr.Error` for excessively large payloads before processing.
+
+## 2025-02-23 - Gradio UI Chat History Limits
+**Vulnerability:** Missing input validation on Gradio chat history state.
+**Learning:** Even if the immediate user message is validated for length, stateful components like `gr.State` or `gr.Chatbot` (which pass history back to the server) can carry massive payloads injected directly into API requests. This can lead to DoS or memory exhaustion during prompt building or tokenization.
+**Prevention:** Always explicitly validate the lengths and sizes of *all* state arrays passed from the client before processing them.

--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -261,6 +261,13 @@ def create_demo():
             # Input length validation to prevent DoS / memory exhaustion
             if len(message) > 4000:
                 raise gr.Error("Message exceeds maximum length limit.")
+            if len(chat_history) > 100:
+                raise gr.Error("Chat history exceeds maximum turns limit.")
+            for msg_obj in chat_history:
+                if len(str(msg_obj.get("content", ""))) > 4000:
+                    raise gr.Error(
+                        "A message in chat history exceeds maximum length limit."
+                    )
 
             # Add user message to both histories
             chat_history = chat_history + [{"role": "user", "content": message}]
@@ -273,7 +280,9 @@ def create_demo():
             # Stream generation
             for partial in generate_stream(
                 message,
-                chat_history[:-1],  # exclude the user msg we just added (it's in the prompt builder)
+                chat_history[
+                    :-1
+                ],  # exclude the user msg we just added (it's in the prompt builder)
                 temperature,
                 top_p,
                 top_k,


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The Gradio demo UI explicitly validated the immediate `message` string length, but failed to validate the lengths and sizes of the `chat_history` array passed by the client. Since Gradio state objects (like `gr.Chatbot`) reflect their entire internal state array back to the server on every request, an attacker could bypass the message size limits by manipulating the history payload in the API request, leading to server-side resource exhaustion, massive tokenization costs, or Denial of Service (DoS).
🎯 **Impact:** Potential memory exhaustion or DoS for hosted demo endpoints if malicious clients hit the API directly.
🔧 **Fix:** Added explicit validation checks in `respond` to enforce a maximum of 100 historical turns and a maximum of 4000 characters per historical message.
✅ **Verification:** Ran `uv run ruff check archive/v3/demo.py`, `uv run pytest`, and manually checked the `respond` logic. Recorded findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13669225634877932439](https://jules.google.com/task/13669225634877932439) started by @CodeHalwell*