### PR TITLE
🛡️ Sentinel: [HIGH] Fix memory exhaustion DoS via Gradio state payloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Missing input length validation in Gradio UI.
 **Learning:** Gradio inputs do not have inherent length limits, allowing excessively large payloads that can lead to Denial of Service (DoS) or memory exhaustion during model inference.
 **Prevention:** Always explicitly validate input string lengths and raise `gr.Error` for excessively large payloads before processing.
+
+## 2024-05-25 - Gradio UI State Payload Limits
+**Vulnerability:** Missing length validation for historical state payloads in Gradio UI.
+**Learning:** Gradio stateful components (like `gr.Chatbot` or `gr.State`) pass history arrays back from the client, allowing malicious actors to bypass immediate input limits by injecting large payloads into the history, leading to memory exhaustion.
+**Prevention:** Always explicitly validate the length of both immediate input strings and historical state payloads (including individual message contents) before processing.

--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -262,6 +262,18 @@ def create_demo():
             if len(message) > 4000:
                 raise gr.Error("Message exceeds maximum length limit.")
 
+            # State payload validation to prevent DoS via malicious history arrays
+            if len(chat_history) > 100 or len(display_history) > 100:
+                raise gr.Error("Conversation history exceeds maximum turn limit.")
+
+            for msg in chat_history:
+                if (
+                    isinstance(msg, dict)
+                    and "content" in msg
+                    and len(msg["content"]) > 16000
+                ):
+                    raise gr.Error("A historical message exceeds maximum length limit.")
+
             # Add user message to both histories
             chat_history = chat_history + [{"role": "user", "content": message}]
             display_history = display_history + [
@@ -273,7 +285,9 @@ def create_demo():
             # Stream generation
             for partial in generate_stream(
                 message,
-                chat_history[:-1],  # exclude the user msg we just added (it's in the prompt builder)
+                chat_history[
+                    :-1
+                ],  # exclude the user msg we just added (it's in the prompt builder)
                 temperature,
                 top_p,
                 top_k,


### PR DESCRIPTION
### 🚨 Severity: HIGH

### 💡 Vulnerability
Gradio stateful components (`gr.Chatbot`, `gr.State`) pass historical conversation arrays back from the client on each request. The demo application previously verified the immediate incoming user `message` length, but did not enforce limits on the `chat_history` or `display_history` payloads. A malicious actor could inject arbitrarily large arrays into the history payload, bypassing immediate text limits.

### 🎯 Impact
Attempting to parse and tokenize massive unstructured payloads would lead to severe memory exhaustion, crashing the model inference or blocking service entirely (Denial of Service).

### 🔧 Fix
Explicitly validate the history structures:
- Limits conversation history to 100 turns.
- Iterates over the historical messages to ensure no pre-existing message exceeds a safe maximum character limit (16,000 chars).
- Throws a clean `gr.Error` before allocating heavy tensors if the limits are breached.

### ✅ Verification
- Test suite executed and passed (`uv run pytest`).
- Successfully logged learning to Sentinel journal (`.jules/sentinel.md`).

---
*PR created automatically by Jules for task [11746269641379637989](https://jules.google.com/task/11746269641379637989) started by @CodeHalwell*