### PR TITLE
🎨 Palette: Enhance chat input multiline support and shortcut hints

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-01 - Add text input shortcuts and multiline
+**Learning:** Adding keyboard shortcut hints in form field `info` parameters clarifies expected behavior for ambiguous submission patterns. In this app, the `gr.Textbox` handles both single-line submissions and multi-line paragraphs, so exposing `max_lines` along with clear instructions directly addresses user friction.
+**Action:** When adding text inputs that support multiline behavior (e.g. Chatbot inputs), include `max_lines` and a clear shortcut hint in the `info` parameter to guide interaction.

--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -180,7 +180,9 @@ def create_demo():
                     placeholder="Ask me anything... (try code or math questions)",
                     label="Message",
                     lines=2,
+                    max_lines=10,
                     autofocus=True,
+                    info="Press Shift+Enter for a new line, or click Send to submit",
                 )
                 with gr.Row():
                     submit_btn = gr.Button("Send", variant="primary")


### PR DESCRIPTION
### 💡 What
Added `max_lines=10` and `info="Press Shift+Enter for a new line, or click Send to submit"` to the `gr.Textbox` in the v3 demo UI.

### 🎯 Why
The chat input frequently handles complex, multi-line prompts (like math problems or code snippets). The default 2-line box forces users to scroll awkwardly for longer inputs. Additionally, without clear affordances, users might not know they can use `Shift+Enter` to insert new lines instead of accidentally submitting prematurely.

### 📸 Before/After
*(Visual changes verified via screenshot generation during testing)*
**Before:** Textbox limited to 2 lines, no helper text.
**After:** Textbox expands up to 10 lines, with helper text below indicating keyboard shortcuts.

### ♿ Accessibility
The `info` parameter adds descriptive text associated with the input field, improving clarity for all users including those using assistive technologies, by explicitly stating the available keyboard interactions.

---
*PR created automatically by Jules for task [11409141660712391359](https://jules.google.com/task/11409141660712391359) started by @CodeHalwell*