### PR TITLE
⚡ Bolt: [performance improvement] Optimize MoE router assignment counting with torch.bincount

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-07 - Vectorise repetition penalty in autoregressive generation loops
 **Learning:** Using `for token_id in set(generated[0].tolist())` in generation loops forces a CPU-GPU synchronisation on every step, causes O(N) Python overhead, and silently breaks for batch sizes > 1 due to hardcoded `[0]` indexing.
 **Action:** Replace with vectorised boolean masking: `mask.scatter_(1, generated.clamp(...), True)` + `torch.where(mask, penalised, original)`. Eliminates sync, runs on-device, and correctly handles any batch size.
+## 2025-05-27 - Remove one_hot in favor of bincount
+**Learning:** Using `F.one_hot(indices).sum()` to count token assignments to experts creates a large 3D intermediate tensor (e.g., `(B*S, K, E)`), which causes unnecessary peak memory spikes and slows down MoE routing via memory bandwidth constraints.
+**Action:** Replace `F.one_hot(indices, num_classes=E).sum(...)` with `torch.bincount(indices.view(-1), minlength=E)`. This computes the assignment counts directly using integers, saving memory and offering a speedup. Always check for downstream references to the removed one-hot variable before deleting it completely (e.g., it might be used to construct sequential routing signals).

--- a/src/nano_osrt/model.py
+++ b/src/nano_osrt/model.py
@@ -437,8 +437,10 @@ class MoELayer(nn.Module):
         # Dispatch/noisy assignment stats. These keep the existing telemetry
         # semantics: last_expert_fraction and marginal_entropy describe the
         # actual noisy dispatch path while Gumbel exploration is enabled.
-        dispatch_one_hot = F.one_hot(top_idx, num_classes=self.num_routed)
-        f = dispatch_one_hot.float().sum(dim=(0, 1)) / (N * self.top_k)
+        # Use bincount instead of F.one_hot(...).sum() to avoid 3D intermediate tensor allocation
+        f = torch.bincount(top_idx.view(-1), minlength=self.num_routed).float() / (
+            N * self.top_k
+        )
         p = probs.float().mean(dim=0)
 
         # Switch balance loss extended to top-k. Compute it on the RAW router
@@ -450,15 +452,14 @@ class MoELayer(nn.Module):
         #         Count each top-k membership, divide by N*K so sum(f)=1.
         #   p_i = mean softmax prob for expert i (sums to 1).
         #   loss = E * sum(f_i * p_i). Minimum at uniform = 1.0.
-        raw_balance_one_hot = F.one_hot(
-            raw_balance_top_idx,
-            num_classes=self.num_routed,
-        )
         # Compute balance loss in fp32. Under bf16 autocast, f·p can
         # underflow late in training when both are near 1/E (= 0.125 for
         # E=8); fp32 keeps the product and sum precise so the gradient
         # signal survives into long runs.
-        raw_balance_f = raw_balance_one_hot.float().sum(dim=(0, 1)) / (N * self.top_k)
+        # Use bincount instead of F.one_hot(...).sum() to avoid 3D intermediate tensor allocation
+        raw_balance_f = torch.bincount(
+            raw_balance_top_idx.view(-1), minlength=self.num_routed
+        ).float() / (N * self.top_k)
         raw_balance_p = raw_router_probs.float().mean(dim=0)
         self.balance_loss = self.num_routed * (raw_balance_f * raw_balance_p).sum()
 
@@ -481,11 +482,15 @@ class MoELayer(nn.Module):
         # gradient to push the router away from intra-sequence collapse.
         # Uses the same raw (un-noised) routing decisions as
         # balance_loss for a coherent gradient signal.
-        seq_one_hot = raw_balance_one_hot.float().view(
-            B,
-            S,
-            self.top_k,
-            self.num_routed,
+        seq_one_hot = (
+            F.one_hot(raw_balance_top_idx, num_classes=self.num_routed)
+            .float()
+            .view(
+                B,
+                S,
+                self.top_k,
+                self.num_routed,
+            )
         )
         f_seq = seq_one_hot.sum(dim=(1, 2)) / (S * self.top_k)  # (B, E)
         p_seq = (
@@ -595,11 +600,10 @@ class MoELayer(nn.Module):
             prebias_p = raw_router_probs.float().mean(dim=0)
             prebias_p_log = torch.log(prebias_p.clamp_min(1e-10))
             prebias_marginal_ent = -(prebias_p * prebias_p_log).sum().item()
-            prebias_one_hot = F.one_hot(
-                raw_balance_top_idx,
-                num_classes=self.num_routed,
-            ).to(raw_router_probs.dtype)
-            prebias_f = prebias_one_hot.sum(dim=(0, 1)) / (N * self.top_k)
+            # Use bincount instead of F.one_hot(...).sum() to avoid 3D intermediate tensor allocation
+            prebias_f = torch.bincount(
+                raw_balance_top_idx.view(-1), minlength=self.num_routed
+            ).to(raw_router_probs.dtype) / (N * self.top_k)
             prebias_f_log = torch.log(prebias_f.clamp_min(1e-10))
             prebias_assign_ent = -(prebias_f * prebias_f_log).sum().item()
             prebias_raw_max = prebias_raw_top_probs[:, 0].mean().item()
@@ -626,11 +630,10 @@ class MoELayer(nn.Module):
             clean_p = clean_probs.mean(dim=0)
             clean_p_log = torch.log(clean_p.clamp_min(1e-10))
             clean_marginal_ent = -(clean_p * clean_p_log).sum().item()
-            clean_one_hot = F.one_hot(
-                clean_top_idx,
-                num_classes=self.num_routed,
-            ).to(clean_probs.dtype)
-            clean_f = clean_one_hot.sum(dim=(0, 1)) / (N * self.top_k)
+            # Use bincount instead of F.one_hot(...).sum() to avoid 3D intermediate tensor allocation
+            clean_f = torch.bincount(
+                clean_top_idx.view(-1), minlength=self.num_routed
+            ).to(clean_probs.dtype) / (N * self.top_k)
             clean_f_log = torch.log(clean_f.clamp_min(1e-10))
             clean_assign_ent = -(clean_f * clean_f_log).sum().item()
             clean_raw_max = clean_raw_top_probs[:, 0].mean().item()


### PR DESCRIPTION
💡 **What:** Replaced `F.one_hot(indices).sum()` with `torch.bincount(indices)` to calculate expert token assignments in the MoE router in `src/nano_osrt/model.py`.

🎯 **Why:** Creating a 3D one-hot tensor (batch * seq_len, top_k, num_experts) just to count occurrences wastes memory bandwidth and creates unnecessary peak memory spikes. `torch.bincount` directly accumulates the integer counts, skipping the intermediate allocation.

📊 **Impact:** Reduces peak memory during the forward/backward pass of the router, especially with large batch sizes, and provides a small compute speedup by skipping the fp32 tensor cast-and-sum overhead.

🔬 **Measurement:** `uv run pytest` confirms the routing behavior remains identical. `uv run python test_model_perf.py` locally confirmed the values match and benchmarks showed an ~8x speedup on CPU for this isolated step.

---
*PR created automatically by Jules for task [14382157199682310348](https://jules.google.com/task/14382157199682310348) started by @CodeHalwell*