### PR TITLE
🎨 Palette: [Add Accordion to Generation Settings]

### DIFF
--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -189,47 +189,47 @@ def create_demo():
                     clear_btn = gr.Button("Clear")
 
             with gr.Column(scale=1):
-                gr.Markdown("### Generation Settings")
-                temperature = gr.Slider(
-                    minimum=0.0,
-                    maximum=2.0,
-                    value=0.2,
-                    step=0.05,
-                    label="Temperature",
-                    info="Controls randomness: lower is focused, higher is creative",
-                )
-                top_p = gr.Slider(
-                    minimum=0.0,
-                    maximum=1.0,
-                    value=0.95,
-                    step=0.05,
-                    label="Top-p",
-                    info="Nucleus sampling: limits tokens to a cumulative probability mass",
-                )
-                top_k = gr.Slider(
-                    minimum=0,
-                    maximum=100,
-                    value=50,
-                    step=5,
-                    label="Top-k",
-                    info="Limits choices to the K most likely tokens",
-                )
-                max_tokens = gr.Slider(
-                    minimum=32,
-                    maximum=1024,
-                    value=512,
-                    step=32,
-                    label="Max tokens",
-                    info="Maximum number of tokens to generate",
-                )
-                repetition_penalty = gr.Slider(
-                    minimum=1.0,
-                    maximum=2.0,
-                    value=1.2,
-                    step=0.05,
-                    label="Repetition penalty",
-                    info="Penalises repeated tokens to reduce loops (1.0 = off)",
-                )
+                with gr.Accordion("Generation Settings", open=False):
+                    temperature = gr.Slider(
+                        minimum=0.0,
+                        maximum=2.0,
+                        value=0.2,
+                        step=0.05,
+                        label="Temperature",
+                        info="Controls randomness: lower is focused, higher is creative",
+                    )
+                    top_p = gr.Slider(
+                        minimum=0.0,
+                        maximum=1.0,
+                        value=0.95,
+                        step=0.05,
+                        label="Top-p",
+                        info="Nucleus sampling: limits tokens to a cumulative probability mass",
+                    )
+                    top_k = gr.Slider(
+                        minimum=0,
+                        maximum=100,
+                        value=50,
+                        step=5,
+                        label="Top-k",
+                        info="Limits choices to the K most likely tokens",
+                    )
+                    max_tokens = gr.Slider(
+                        minimum=32,
+                        maximum=1024,
+                        value=512,
+                        step=32,
+                        label="Max tokens",
+                        info="Maximum number of tokens to generate",
+                    )
+                    repetition_penalty = gr.Slider(
+                        minimum=1.0,
+                        maximum=2.0,
+                        value=1.2,
+                        step=0.05,
+                        label="Repetition penalty",
+                        info="Penalises repeated tokens to reduce loops (1.0 = off)",
+                    )
 
                 gr.Markdown(
                     "### Model Info\n"


### PR DESCRIPTION
### 💡 What
Wrapped the "Generation Settings" section (Temperature, Top-p, Top-k, Max tokens, Repetition penalty) in a collapsible `gr.Accordion` container that is closed by default in the Gradio UI.

### 🎯 Why
The generation settings took up significant screen real estate alongside the chat interface. For casual users, these settings are rarely tweaked. Wrapping them in an accordion declutters the primary UI, reducing cognitive load while ensuring advanced parameters remain accessible to power users.

### 📸 Before/After
*   **Before:** Generation settings sliders were permanently expanded under "### Generation Settings".
*   **After:** Generation settings are neatly tucked away inside an expandable "Generation Settings" accordion header.

### ♿ Accessibility
The `gr.Accordion` natively supports keyboard navigation (tabbing to focus, space/enter to toggle), preserving keyboard accessibility for the settings panel.

---
*PR created automatically by Jules for task [4827524636953054411](https://jules.google.com/task/4827524636953054411) started by @CodeHalwell*