### PR TITLE
🎨 Palette: Add Stop button to Gradio demo to stop generation

### DIFF
--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -186,6 +186,7 @@ def create_demo():
                 )
                 with gr.Row():
                     submit_btn = gr.Button("Send", variant="primary")
+                    stop_btn = gr.Button("Stop", variant="stop")
                     clear_btn = gr.Button("Clear")
 
             with gr.Column(scale=1):
@@ -312,7 +313,7 @@ def create_demo():
             chat_history = chat_history + [{"role": "assistant", "content": final}]
             yield chat_history, display_history, ""
 
-        msg.submit(
+        msg_event = msg.submit(
             respond,
             [
                 msg,
@@ -326,7 +327,7 @@ def create_demo():
             ],
             [chat_state, chatbot, msg],
         )
-        submit_btn.click(
+        sub_event = submit_btn.click(
             respond,
             [
                 msg,
@@ -339,6 +340,9 @@ def create_demo():
                 repetition_penalty,
             ],
             [chat_state, chatbot, msg],
+        )
+        stop_btn.click(
+            fn=None, inputs=None, outputs=None, cancels=[msg_event, sub_event]
         )
         clear_btn.click(lambda: ([], [], ""), outputs=[chat_state, chatbot, msg])
 


### PR DESCRIPTION
### 💡 What
Added a "Stop" button next to "Send" and "Clear" in the Gradio UI. The button interrupts the stream generation when clicked.

### 🎯 Why
Long-running generation tasks can be frustrating if a user realizes they made a mistake in their prompt or if the model starts hallucinating. Providing a way to cancel the generation directly in the UI significantly improves the user experience.

### 📸 Before/After
**Before:** Only "Send" and "Clear" buttons were available. Users had to wait for generation to complete or refresh the page.
**After:** A "Stop" button allows users to gracefully interrupt the generation stream.

### ♿ Accessibility
The button uses the built-in Gradio `variant="stop"` token for styling, keeping it consistent with the existing UI and clearly identifiable as a destructive/interruptive action.

---
*PR created automatically by Jules for task [7044020529408995147](https://jules.google.com/task/7044020529408995147) started by @CodeHalwell*