### PR TITLE
feat: integrate PR #114 — Gradio UX improvements + vectorised repetition penalty

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,19 @@
 ## 2024-06-11 - Torch bincount over F.one_hot for MoE Router Counts
 **Learning:** In PyTorch, when calculating expert fractions or aggregating occurrences in MoE routing, `F.one_hot(indices, num_classes=E).sum()` creates massive 3D intermediate tensors of shape `(Batch * SeqLen, TopK, NumExperts)`.
 **Action:** Always replace `F.one_hot(...).sum()` with `torch.bincount(indices.view(-1), minlength=E)` for 1D counts, or use `scatter_add_` for 2D batch grouping, to save memory bandwidth and speed up forward passes.
+
+## 2025-02-23 - Avoid intermediate full-size tensor allocation in element-wise math
+**Learning:** In PyTorch, allocating large intermediate tensors (like `torch.cat([-x2, x1], dim=-1)` for RoPE) inside high-frequency functions causes memory bandwidth bottlenecks.
+**Action:** When performing element-wise math on sliced tensors, calculate and concatenate the results directly (`torch.cat([math_part1, math_part2], dim=-1)`) instead of allocating intermediate full-size tensors. This reduces memory bandwidth usage and lowers latency, especially on GPU hardware.
+
+## 2024-05-07 - Vectorise repetition penalty in autoregressive generation loops
+**Learning:** Using `for token_id in set(generated[0].tolist())` in generation loops forces a CPU-GPU synchronisation on every step, causes O(N) Python overhead, and silently breaks for batch sizes > 1 due to hardcoded `[0]` indexing.
+**Action:** Replace with vectorised boolean masking: `mask.scatter_(1, generated.clamp(...), True)` + `torch.where(mask, penalised, original)`. Eliminates sync, runs on-device, and correctly handles any batch size.
+
+## 2025-05-27 - Remove one_hot in favor of bincount
+**Learning:** Using `F.one_hot(indices).sum()` to count token assignments to experts creates a large 3D intermediate tensor (e.g., `(B*S, K, E)`), which causes unnecessary peak memory spikes and slows down MoE routing via memory bandwidth constraints.
+**Action:** Replace `F.one_hot(indices, num_classes=E).sum(...)` with `torch.bincount(indices.view(-1), minlength=E)`. This computes the assignment counts directly using integers, saving memory and offering a speedup. Always check for downstream references to the removed one-hot variable before deleting it completely (e.g., it might be used to construct sequential routing signals).
+
+## 2025-05-29 - Avoid one_hot for 2D aggregation
+**Learning:** Using `F.one_hot(...).sum()` to count occurrences where a 2D grouping (like per batch item) is needed creates a large 4D intermediate tensor.
+**Action:** Initialize a zero tensor (`torch.zeros(B, E)`) and use `scatter_add_` with a tensor of ones to accumulate counts. This provides a significant speedup and prevents out-of-memory bottlenecks.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-03-01 - Add text input shortcuts and multiline
+**Learning:** Adding keyboard shortcut hints in form field `info` parameters clarifies expected behavior for ambiguous submission patterns. In this app, the `gr.Textbox` handles both single-line submissions and multi-line paragraphs, so exposing `max_lines` along with clear instructions directly addresses user friction.
+**Action:** When adding text inputs that support multiline behavior (e.g. Chatbot inputs), include `max_lines` and a clear shortcut hint in the `info` parameter to guide interaction.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,18 @@
 **Vulnerability:** Python sandboxed subprocess execution via `subprocess.Popen` in `mbpp_test_reward` (in `archive/v5/src/nano_osrt/rewards.py`) allows untrusted code to run. While the environment is restricted (cleared env dict), it relies on Python's default behavior for module loading. By default, Python adds the current working directory to `sys.path` and attempts to load packages from the user site-packages directory. Even though `cwd` is set to a tempdir, if an attacker can write a file to `~/.local/lib/pythonX.Y/site-packages` or if an existing user package is present, they could execute arbitrary code when an innocent module is imported by standard library imports.
 **Learning:** When creating a minimal, restricted environment for Python `subprocess.Popen` to execute untrusted code securely, relying on a stripped `os.environ` is insufficient if Python-specific module loading environment variables aren't explicitly mitigated.
 **Prevention:** Always explicitly set `PYTHONNOUSERSITE=1` and `PYTHONPATH=""` in the `sandbox_env` when executing untrusted Python code to prevent sandbox evasion via local module shadowing and pre-installed user site packages.
+
+## 2024-05-22 - Gradio UI Input Length Limits
+**Vulnerability:** Missing input length validation in Gradio UI.
+**Learning:** Gradio inputs do not have inherent length limits, allowing excessively large payloads that can lead to Denial of Service (DoS) or memory exhaustion during model inference.
+**Prevention:** Always explicitly validate input string lengths and raise `gr.Error` for excessively large payloads before processing.
+
+## 2024-05-25 - Gradio UI State Payload Limits
+**Vulnerability:** Missing length validation for historical state payloads in Gradio UI.
+**Learning:** Gradio stateful components (like `gr.Chatbot` or `gr.State`) pass history arrays back from the client, allowing malicious actors to bypass immediate input limits by injecting large payloads into the history, leading to memory exhaustion.
+**Prevention:** Always explicitly validate the length of both immediate input strings and historical state payloads (including individual message contents) before processing.
+
+## 2024-05-29 - ReDoS in Whitespace Regex
+**Vulnerability:** Regular Expression Denial of Service (ReDoS) due to overlapping whitespace matches.
+**Learning:** Using `\s*` adjacent to `(?:^|\n)` causes overlapping backtracking paths (O(N^2) complexity) because `\s` includes `\n`. This makes parsing vulnerable to crafted inputs with alternating spaces and newlines.
+**Prevention:** Use `[ \t]*` or `[^\S\n]*` instead of `\s*` when you only want to match horizontal whitespace next to a newline boundary.

--- a/archive/v3/demo.py
+++ b/archive/v3/demo.py
@@ -10,9 +10,8 @@ import argparse
 
 import gradio as gr
 import torch
-from transformers import AutoTokenizer
-
 from src.nano_osrt.hf_model import NanoOSRTForCausalLM
+from transformers import AutoTokenizer
 
 # ── Model loading ───────────────────────────────────────────────────────
 
@@ -92,24 +91,39 @@ def generate_stream(
 
     with torch.no_grad():
         for i in range(max_tokens):
-            context = generated[:, -MODEL.config.seq_len:]
+            context = generated[:, -MODEL.config.seq_len :]
             out = MODEL.forward(context)
-            next_logits = out["logits"][:, -1, :MODEL.config.real_vocab_size].float()
+            next_logits = out["logits"][:, -1, : MODEL.config.real_vocab_size].float()
 
-            # Repetition penalty
+            # Repetition penalty: vectorised boolean mask avoids CPU-GPU sync
+            # and supports batch sizes > 1 (original loop hardcoded [0]).
             if repetition_penalty != 1.0:
-                for token_id in set(generated[0].tolist()):
-                    if token_id < next_logits.shape[-1]:
-                        if next_logits[0, token_id] > 0:
-                            next_logits[0, token_id] /= repetition_penalty
-                        else:
-                            next_logits[0, token_id] *= repetition_penalty
+                vocab_size = next_logits.shape[-1]
+                mask = torch.zeros(
+                    (generated.shape[0], vocab_size),
+                    dtype=torch.bool,
+                    device=next_logits.device,
+                )
+                clamped = generated.clamp(max=vocab_size - 1)
+                mask.scatter_(1, clamped, True)
+                mask &= generated < vocab_size  # exclude out-of-vocab ids
+                next_logits = torch.where(
+                    mask,
+                    torch.where(
+                        next_logits > 0,
+                        next_logits / repetition_penalty,
+                        next_logits * repetition_penalty,
+                    ),
+                    next_logits,
+                )
 
             if temperature > 0:
                 next_logits = next_logits / temperature
 
                 if top_k > 0:
-                    topk_vals, _ = torch.topk(next_logits, min(top_k, next_logits.size(-1)))
+                    topk_vals, _ = torch.topk(
+                        next_logits, min(top_k, next_logits.size(-1))
+                    )
                     next_logits[next_logits < topk_vals[:, -1:]] = float("-inf")
 
                 sorted_logits, sorted_indices = torch.sort(next_logits, descending=True)
@@ -140,6 +154,7 @@ def generate_stream(
 
 # ── Gradio UI ───────────────────────────────────────────────────────────
 
+
 def create_demo():
     with gr.Blocks(title="NanoOSRT v3") as demo:
         gr.Markdown(
@@ -156,38 +171,67 @@ def create_demo():
 
         with gr.Row():
             with gr.Column(scale=3):
-                chatbot = gr.Chatbot(height=500, label="Chat")
+                chatbot = gr.Chatbot(
+                    height=500,
+                    label="Chat",
+                    placeholder="**NanoOSRT v3**\n\nReady to chat! Try selecting one of the examples below or ask me a math or coding question.",
+                    buttons=["copy", "share"],
+                )
                 msg = gr.Textbox(
                     placeholder="Ask me anything... (try code or math questions)",
                     label="Message",
                     lines=2,
+                    max_lines=10,
+                    autofocus=True,
+                    info="Press Shift+Enter for a new line, or click Send to submit",
                 )
                 with gr.Row():
                     submit_btn = gr.Button("Send", variant="primary")
+                    stop_btn = gr.Button("Stop", variant="stop")
                     clear_btn = gr.Button("Clear")
 
             with gr.Column(scale=1):
-                gr.Markdown("### Generation Settings")
-                temperature = gr.Slider(
-                    minimum=0.0, maximum=2.0, value=0.2, step=0.05,
-                    label="Temperature",
-                )
-                top_p = gr.Slider(
-                    minimum=0.0, maximum=1.0, value=0.95, step=0.05,
-                    label="Top-p",
-                )
-                top_k = gr.Slider(
-                    minimum=0, maximum=100, value=50, step=5,
-                    label="Top-k",
-                )
-                max_tokens = gr.Slider(
-                    minimum=32, maximum=1024, value=512, step=32,
-                    label="Max tokens",
-                )
-                repetition_penalty = gr.Slider(
-                    minimum=1.0, maximum=2.0, value=1.2, step=0.05,
-                    label="Repetition penalty",
-                )
+                with gr.Accordion("Generation Settings", open=False):
+                    temperature = gr.Slider(
+                        minimum=0.0,
+                        maximum=2.0,
+                        value=0.2,
+                        step=0.05,
+                        label="Temperature",
+                        info="Controls randomness: lower is focused, higher is creative",
+                    )
+                    top_p = gr.Slider(
+                        minimum=0.0,
+                        maximum=1.0,
+                        value=0.95,
+                        step=0.05,
+                        label="Top-p",
+                        info="Nucleus sampling: limits tokens to a cumulative probability mass",
+                    )
+                    top_k = gr.Slider(
+                        minimum=0,
+                        maximum=100,
+                        value=50,
+                        step=5,
+                        label="Top-k",
+                        info="Limits choices to the K most likely tokens",
+                    )
+                    max_tokens = gr.Slider(
+                        minimum=32,
+                        maximum=1024,
+                        value=512,
+                        step=32,
+                        label="Max tokens",
+                        info="Maximum number of tokens to generate",
+                    )
+                    repetition_penalty = gr.Slider(
+                        minimum=1.0,
+                        maximum=2.0,
+                        value=1.2,
+                        step=0.05,
+                        label="Repetition penalty",
+                        info="Penalises repeated tokens to reduce loops (1.0 = off)",
+                    )
 
                 gr.Markdown(
                     "### Model Info\n"
@@ -212,8 +256,32 @@ def create_demo():
             label="Try these examples",
         )
 
-        def respond(message, chat_history, display_history,
-                    temperature, top_p, top_k, max_tokens, repetition_penalty):
+        def respond(
+            message,
+            chat_history,
+            display_history,
+            temperature,
+            top_p,
+            top_k,
+            max_tokens,
+            repetition_penalty,
+        ):
+            # Input length validation to prevent DoS / memory exhaustion
+            if len(message) > 4000:
+                raise gr.Error("Message exceeds maximum length limit.")
+
+            # State payload validation to prevent DoS via malicious history arrays
+            if len(chat_history) > 100 or len(display_history) > 100:
+                raise gr.Error("Conversation history exceeds maximum turn limit.")
+
+            for msg in chat_history:
+                if (
+                    isinstance(msg, dict)
+                    and "content" in msg
+                    and len(msg["content"]) > 16000
+                ):
+                    raise gr.Error("A historical message exceeds maximum length limit.")
+
             # Add user message to both histories
             chat_history = chat_history + [{"role": "user", "content": message}]
             display_history = display_history + [
@@ -224,26 +292,58 @@ def create_demo():
 
             # Stream generation
             for partial in generate_stream(
-                message, chat_history[:-1],  # exclude the user msg we just added (it's in the prompt builder)
-                temperature, top_p, top_k, max_tokens, repetition_penalty,
+                message,
+                chat_history[
+                    :-1
+                ],  # exclude the user msg we just added (it's in the prompt builder)
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
             ):
                 display_history[-1] = gr.ChatMessage(role="assistant", content=partial)
                 yield chat_history, display_history, ""
 
             # Save final assistant response to chat_history
-            final = display_history[-1].content if hasattr(display_history[-1], 'content') else ""
+            final = (
+                display_history[-1].content
+                if hasattr(display_history[-1], "content")
+                else ""
+            )
             chat_history = chat_history + [{"role": "assistant", "content": final}]
             yield chat_history, display_history, ""
 
-        msg.submit(
+        msg_event = msg.submit(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
         )
-        submit_btn.click(
+        sub_event = submit_btn.click(
             respond,
-            [msg, chat_state, chatbot, temperature, top_p, top_k, max_tokens, repetition_penalty],
+            [
+                msg,
+                chat_state,
+                chatbot,
+                temperature,
+                top_p,
+                top_k,
+                max_tokens,
+                repetition_penalty,
+            ],
             [chat_state, chatbot, msg],
+        )
+        stop_btn.click(
+            fn=None, inputs=None, outputs=None, cancels=[msg_event, sub_event]
         )
         clear_btn.click(lambda: ([], [], ""), outputs=[chat_state, chatbot, msg])
 

--- a/archive/v3/src/hf_model.py
+++ b/archive/v3/src/hf_model.py
@@ -378,14 +378,27 @@ class NanoOSRTForCausalLM(nn.Module):
                     out["logits"][:, -1, :self.config.real_vocab_size].float()
                 )
 
-            # Repetition penalty: reduce logits for tokens already generated
+            # Repetition penalty: vectorised boolean mask avoids CPU-GPU sync
+            # and supports batch sizes > 1 (original loop hardcoded [0]).
             if repetition_penalty != 1.0:
-                for token_id in set(generated[0].tolist()):
-                    if token_id < next_logits.shape[-1]:
-                        if next_logits[0, token_id] > 0:
-                            next_logits[0, token_id] /= repetition_penalty
-                        else:
-                            next_logits[0, token_id] *= repetition_penalty
+                vocab_size = next_logits.shape[-1]
+                mask = torch.zeros(
+                    (generated.shape[0], vocab_size),
+                    dtype=torch.bool,
+                    device=next_logits.device,
+                )
+                clamped = generated.clamp(max=vocab_size - 1)
+                mask.scatter_(1, clamped, True)
+                mask &= generated < vocab_size  # exclude out-of-vocab ids
+                next_logits = torch.where(
+                    mask,
+                    torch.where(
+                        next_logits > 0,
+                        next_logits / repetition_penalty,
+                        next_logits * repetition_penalty,
+                    ),
+                    next_logits,
+                )
 
             if temperature > 0:
                 next_logits = next_logits / temperature


### PR DESCRIPTION
## Summary

Integrates the applicable changes from PR #114 (Palette: Add copy and share buttons) onto the current main. The `src/nano_osrt/model.py` and `src/nano_osrt/rewards.py` changes from that PR were skipped because the `src/` directory was restructured after #114 was opened and those files no longer exist at those paths.

**What's included:**
- `archive/v3/demo.py`: Stop button, collapsible Accordion settings, copy/share buttons on Chatbot, multiline textbox with keyboard hint, autofocus, per-slider info strings, input/history length validation (DoS prevention), vectorised repetition penalty mask (fixes batch>1 bug)
- `archive/v3/src/hf_model.py`: Same vectorised repetition penalty fix
- `.jules/bolt.md`, `.jules/sentinel.md`, `.jules/palette.md`: Consolidated journal entries from PRs #114–#119

**Related:** Closes #114. PRs #115 and #118 were already closed as duplicates. PRs #116, #117, and #119 were already merged directly to main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBw1c8Ans7TLmo1tjJEUY3)_